### PR TITLE
more features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <maven-clover2-plugin.version>4.0.5</maven-clover2-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven-surefire-plugin.version>2.17</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <enforcer.skip>true</enforcer.skip>
         <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>

--- a/src/main/java/com/yahoo/sherlock/App.java
+++ b/src/main/java/com/yahoo/sherlock/App.java
@@ -200,6 +200,15 @@ class App {
         // Routes to Clear all reports of selected jobs
         post("/Meta-Manager/ClearReports/:ids", Routes::clearReportsOfSelectedJobs);
 
+        // Routes to view Emails
+        get("/Emails/:id", Routes::viewEmails, new ThymeleafTemplateEngine());
+
+        // Routes to update Emails
+        post("/Emails/:id", Routes::updateEmails);
+
+        // Routes to delete Email
+        post("/DeleteEmail/:id", Routes::deleteEmail);
+
         // Enable debug routes only in debug mode
         if (CLISettings.DEBUG_MODE) {
             // Routes to get the database as a JSON dump
@@ -220,6 +229,10 @@ class App {
             get("/Debug/EgadsQuery", Routes::debugShowEgadsConfigurableQuery, new ThymeleafTemplateEngine());
             // Submit egads query
             post("/Debug/EgadsQuery", Routes::debugPerformEgadsQuery);
+            // Restore redis db form
+            get("/Debug/Restore", Routes::restoreRedisDBForm, new ThymeleafTemplateEngine());
+            // Restore redis db
+            post("/Debug/Restore", Routes::restoreRedisDB);
         }
 
         initRoutes();

--- a/src/main/java/com/yahoo/sherlock/enums/Triggers.java
+++ b/src/main/java/com/yahoo/sherlock/enums/Triggers.java
@@ -11,10 +11,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Triggers for every minute, hourly, daily, weekly and monthly cron jobs.
+ * Triggers for instant and every minute, hourly, daily, weekly and monthly cron jobs.
  */
 public enum Triggers {
-    MINUTE(1), HOUR(60), DAY(1440), WEEK(10080), MONTH(43800);
+    INSTANT(0), MINUTE(1), HOUR(60), DAY(1440), WEEK(10080), MONTH(43800);
 
     /**
      * Trigger value in minutes for job scheduling.

--- a/src/main/java/com/yahoo/sherlock/exception/EmailNotFoundException.java
+++ b/src/main/java/com/yahoo/sherlock/exception/EmailNotFoundException.java
@@ -1,0 +1,35 @@
+package com.yahoo.sherlock.exception;
+
+/**
+ * Exception thrown when no {@code EmailMetadata} can be
+ * found with a specified emailId.
+ */
+public class EmailNotFoundException extends Exception {
+
+    /**
+     * Default constructor.
+     */
+    public EmailNotFoundException() {
+        super();
+    }
+
+    /**
+     * Constructor with a message.
+     *
+     * @param message exception message
+     */
+    public EmailNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor with a message and a throwable.
+     *
+     * @param message exception message
+     * @param cause   cause of exception
+     */
+    public EmailNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/com/yahoo/sherlock/model/DruidCluster.java
+++ b/src/main/java/com/yahoo/sherlock/model/DruidCluster.java
@@ -133,6 +133,8 @@ public class DruidCluster implements Serializable {
             errorMsg = "Broker port must be a non-negative number";
         } else if (brokerHost.contains("/") || brokerHost.contains(":")) {
             errorMsg = "Broker host should not contain any '/' or ':' characters";
+        } else if (!isAllowedHost(brokerHost, brokerPort)) {
+            errorMsg = "Broker host or port specified is not allowed!";
         } else {
             if (clusterDescription == null) {
                 clusterDescription = "";
@@ -172,6 +174,16 @@ public class DruidCluster implements Serializable {
         setBrokerEndpoint(newCluster.getBrokerEndpoint());
         setHoursOfLag(newCluster.getHoursOfLag());
         setProtocol(newCluster.getProtocol());
+    }
+
+    /**
+     * Methos to check druid broker uri in allowed brokers list.
+     * @param host broker host
+     * @param port broker port
+     * @return true if allowed to access else false
+     */
+    private boolean isAllowedHost(String host, Integer port) {
+        return Constants.VALID_DRUID_BROKERS == null || Constants.VALID_DRUID_BROKERS.contains(String.format("%s:%s", host, port));
     }
 
     /**

--- a/src/main/java/com/yahoo/sherlock/model/EmailMetaData.java
+++ b/src/main/java/com/yahoo/sherlock/model/EmailMetaData.java
@@ -1,0 +1,93 @@
+package com.yahoo.sherlock.model;
+
+import com.yahoo.sherlock.enums.Triggers;
+import com.yahoo.sherlock.store.Attribute;
+
+import java.io.Serializable;
+
+import lombok.Data;
+
+/**
+ * Data storer for email id metadata.
+ */
+@Data
+public class EmailMetaData implements Serializable {
+
+    /**
+     * Serialization id for uniformity across platform.
+     */
+    private static final long serialVersionUID = 31L;
+
+    /**
+     * EmailId value.
+     */
+    @Attribute
+    private String emailId;
+
+    /**
+     * Hours value(0-23) to send out email.
+     */
+    @Attribute
+    private String sendOutHour = "12";
+
+    /**
+     * Minutes value(0-59) to send out email.
+     */
+    @Attribute
+    private String sendOutMinute = "00";
+
+    /**
+     * Email sendout repeat interval.
+     * It can have six values: {@link Triggers}
+     */
+    @Attribute
+    private String repeatInterval = Triggers.INSTANT.toString();
+
+    /**
+     * Default constructor.
+     */
+    public EmailMetaData() {
+
+    }
+
+    /**
+     * Constructor to intialize default object.
+     * @param emailId emailId to add
+     */
+    public EmailMetaData(String emailId) {
+        this.emailId = emailId;
+    }
+
+    /**
+     * Constructor with params.
+     * @param emailId        emailId to add
+     * @param sendOutHour    send out hour value(0-23)
+     * @param sendOutMinute  send out hour value(0-23)
+     * @param repeatInterval email send out interval value: possible values {@link Triggers}
+     */
+    public EmailMetaData(String emailId, String sendOutHour, String sendOutMinute, String repeatInterval) {
+        this.emailId = emailId;
+        this.sendOutHour = sendOutHour;
+        this.sendOutMinute = sendOutMinute;
+        this.repeatInterval = repeatInterval;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EmailMetaData)) {
+            return false;
+        }
+
+        EmailMetaData that = (EmailMetaData) o;
+
+        return emailId.equals(that.emailId);
+    }
+
+    @Override
+    public int hashCode() {
+        return emailId.hashCode();
+    }
+}

--- a/src/main/java/com/yahoo/sherlock/query/Query.java
+++ b/src/main/java/com/yahoo/sherlock/query/Query.java
@@ -144,7 +144,20 @@ public class Query {
         // check for multiple dimensions
         if (this.queryObj.has(QueryConstants.DIMENSIONS) && this.queryObj.get(QueryConstants.DIMENSIONS).isJsonArray()) {
             JsonArray dimensionsArray = this.queryObj.getAsJsonArray(QueryConstants.DIMENSIONS);              // get dimensions as an array
-            dimensionsArray.forEach(jsonElement -> dimensions.add(jsonElement.getAsString()));                // make a set of dimensions
+            dimensionsArray.forEach(jsonElement -> {
+                    if (jsonElement.isJsonObject()) {
+                        JsonObject jsonObject = jsonElement.getAsJsonObject();
+                        String dimName = QueryConstants.UNKNOWN;
+                        if (jsonObject.has(QueryConstants.OUTPUT_NAME)) {
+                            dimName = jsonObject.getAsJsonPrimitive(QueryConstants.OUTPUT_NAME).getAsString();
+                        } else if (jsonObject.has(QueryConstants.DIMENSION)) {
+                            dimName = jsonObject.getAsJsonPrimitive(QueryConstants.DIMENSION).getAsString();
+                        }
+                        dimensions.add(dimName);
+                    } else {
+                        dimensions.add(jsonElement.getAsString());
+                    }
+                });                                                                                               // make a set of dimensions
         } else if (this.queryObj.has(QueryConstants.DIMENSION)) {                                             // check for single dimension
             dimensions.add(this.queryObj.getAsJsonPrimitive(QueryConstants.DIMENSION).getAsString());
         }

--- a/src/main/java/com/yahoo/sherlock/service/EmailService.java
+++ b/src/main/java/com/yahoo/sherlock/service/EmailService.java
@@ -6,10 +6,16 @@
 
 package com.yahoo.sherlock.service;
 
+import com.yahoo.sherlock.enums.Triggers;
 import com.yahoo.sherlock.model.AnomalyReport;
+import com.yahoo.sherlock.model.EmailMetaData;
+import com.yahoo.sherlock.model.JobMetadata;
 import com.yahoo.sherlock.settings.CLISettings;
 import com.yahoo.sherlock.settings.Constants;
 import com.yahoo.sherlock.settings.DatabaseConstants;
+import com.yahoo.sherlock.store.AnomalyReportAccessor;
+import com.yahoo.sherlock.store.EmailMetadataAccessor;
+import com.yahoo.sherlock.store.Store;
 import lombok.extern.slf4j.Slf4j;
 import org.simplejavamail.email.Email;
 import org.simplejavamail.mailer.Mailer;
@@ -18,12 +24,16 @@ import org.simplejavamail.mailer.config.TransportStrategy;
 import spark.ModelAndView;
 import spark.template.thymeleaf.ThymeleafTemplateEngine;
 
+import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 /**
  * Emailer class for email service.
@@ -37,7 +47,30 @@ public class EmailService {
      * by '|' using String.format.
      */
     private static final String EMAIL_PATTERN =
-        "^[a-zA-Z0-9_.+-]+@(?:(?:[a-zA-Z0-9-]+\\.)?[a-zA-Z]+\\.)?(%s)\\.[a-z]{0,3}$";
+            "^[a-zA-Z0-9_.+-]+@(%s).[a-z]{0,3}$";
+    /**
+     * Valid email regex.
+     */
+    private static final String VALID_EMAIL =
+            "^[a-zA-Z0-9_.+-]+@(([a-zA-Z0-9-]+)(\\.[a-zA-Z0-9-]+)?).[a-z]{0,3}$";
+
+    /**
+     * EmailMetadataAccessor object.
+     */
+    protected EmailMetadataAccessor emailMetadataAccessor;
+
+    /**
+     * AnomalyReportAccessor object.
+     */
+    protected AnomalyReportAccessor anomalyReportAccessor;
+
+    /**
+     * Constructor.
+     */
+    public EmailService() {
+        emailMetadataAccessor = Store.getEmailMetadataAccessor();
+        anomalyReportAccessor = Store.getAnomalyReportAccessor();
+    }
 
     /**
      * Gets a list of valid domains, which may be empty, from the
@@ -65,21 +98,25 @@ public class EmailService {
      */
     public boolean validateEmail(String email, List<String> validDomains) {
         String[] allEmails = email.replace(" ", "").split(Constants.COMMA_DELIMITER);
-        if (email == null || email.isEmpty()) {
+        if (email.isEmpty()) {
             return false;
         }
         if (validDomains.isEmpty()) {
-            // Empty domains list means all domains are valid
-            return true;
+            boolean result = true;
+            for (String oneEmail : allEmails) {
+                result = result && oneEmail.matches(VALID_EMAIL);
+            }
+            return result;
         }
-        StringJoiner joiner = new StringJoiner("|");
+        StringJoiner joiner = new StringJoiner(Constants.PIPE_DELIMITER);
         for (String validDomain : validDomains) {
             joiner.add(validDomain);
         }
         String domainsMatcher = joiner.toString();
         boolean result = true;
         for (String oneEmail : allEmails) {
-            result = result && oneEmail.matches(String.format(EMAIL_PATTERN, domainsMatcher));
+            String s = String.format(EMAIL_PATTERN, domainsMatcher);
+            result = result && oneEmail.matches(s);
         }
         return result;
     }
@@ -87,58 +124,143 @@ public class EmailService {
     /**
      * Create the emaile handle.
      * @param owner owner name
-     * @param ownerEmailIdList owner email ids
+     * @param ownerEmailIdList owner email ids list
      * @return email handle
      */
-    public Email createEmailHandle(String owner, String ownerEmailIdList) {
+    public Email createEmailHandle(String owner, List<String> ownerEmailIdList) {
         Email emailHandle = new Email();
         emailHandle.setFromAddress(Constants.SHERLOCK, CLISettings.FROM_MAIL);
         emailHandle.setReplyToAddress(Constants.SHERLOCK, CLISettings.REPLY_TO);
-        emailHandle.addNamedToRecipients(owner, ownerEmailIdList.split(Constants.COMMA_DELIMITER));
+        String[] emails = ownerEmailIdList.stream().toArray(size -> new String[size]);
+        emailHandle.addNamedToRecipients(owner, emails);
         return emailHandle;
+    }
+
+    /**
+     * Sends the consolidated alerts over the specified trigger period.
+     * @param zonedDateTime current date as ZonedDateTime object
+     * @param trigger trigger name value
+     */
+    public void sendConsolidatedEmail(ZonedDateTime zonedDateTime, String trigger) throws IOException {
+        List<EmailMetaData> emails = emailMetadataAccessor.getAllEmailMetadataByTrigger(trigger);
+        log.info("Found {} emails for {} trigger index", emails.size(), trigger);
+        for (EmailMetaData emailMetaData : emails) {
+            int hour = Integer.valueOf(emailMetaData.getSendOutHour());
+            int minute = Integer.valueOf(emailMetaData.getSendOutMinute());
+            boolean isTimeToSend = trigger.equalsIgnoreCase(Triggers.HOUR.toString()) ?
+                                   zonedDateTime.getMinute() == minute :
+                                   zonedDateTime.getHour() == hour && zonedDateTime.getMinute() == minute;
+            if (isTimeToSend) {
+                List<AnomalyReport> anomalyReports = anomalyReportAccessor.getAnomalyReportsForEmailId(emailMetaData.getEmailId());
+                List<AnomalyReport> filteredReports = anomalyReports.stream()
+                    .filter(a -> !a.getStatus().equalsIgnoreCase(Constants.SUCCESS))
+                    .collect(Collectors.toList());
+                log.info("Sending {} anomaly reports to {}", filteredReports.size(), emailMetaData.getEmailId());
+                if (filteredReports.size() > 0) {
+                    if (!sendEmail(Constants.SHERLOCK, Arrays.asList(emailMetaData.getEmailId()), filteredReports)) {
+                        log.error("Error while sending email: {}, trigger: {}!", emailMetaData.getEmailId(), trigger);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Method to send emails to given emailIds.
+     * @param job            job for which the anomalies are found
+     * @param emails         list of email ids
+     * @param anomalyReports list of anomaly reports
+     */
+    public void processEmailReports(JobMetadata job, List<String> emails, List<AnomalyReport> anomalyReports) {
+        anomalyReports = anomalyReports.stream()
+            .filter(a -> !a.getStatus().equalsIgnoreCase(Constants.SUCCESS))
+            .collect(Collectors.toList());
+        if (CLISettings.ENABLE_EMAIL) {
+            if (isErrorCase(anomalyReports)) {
+                if (!sendEmail(CLISettings.FAILURE_EMAIL, Arrays.asList(CLISettings.FAILURE_EMAIL), anomalyReports)) {
+                    log.error("Error while sending failure email!");
+                }
+            } else if (isNoDataCase(anomalyReports)) {
+                if (job.getEmailOnNoData()) {
+                    if (!sendEmail(job.getOwner(), emails, anomalyReports)) {
+                        log.error("Error while sending Nodata email!");
+                    }
+                }
+            } else {
+                if (!sendEmail(job.getOwner(), emails, anomalyReports)) {
+                    log.error("Error while sending anomaly report email!");
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper to identify Error case in anomaly reports.
+     * @param anomalyReports input list of anomaly reports
+     * @return true if error case else false
+     */
+    private boolean isErrorCase(List<AnomalyReport> anomalyReports) {
+        return anomalyReports.size() == 1 && anomalyReports.get(0).getStatus().equals(Constants.ERROR);
+    }
+
+    /**
+     * Helper to identify Nodata case in anomaly reports.
+     * @param anomalyReports input list of anomaly reports
+     * @return true if no data case else false
+     */
+    private boolean isNoDataCase(List<AnomalyReport> anomalyReports) {
+        return anomalyReports.size() == 1 && anomalyReports.get(0).getStatus().equals(Constants.NODATA);
     }
 
     /**
      * Method for email service.
      * @param owner owner name
-     * @param ownerEmailIdList owner email ids
-     * @param report anomaly report as a list of anomalies
+     * @param emails owner email ids list
+     * @param anomalyReports anomaly report as a list of anomalies
      * @return status of email: true for success, false for error
      */
-    public boolean sendEmail(String owner, String ownerEmailIdList, List<AnomalyReport> report) {
+    public boolean sendEmail(String owner, List<String> emails, List<AnomalyReport> anomalyReports) {
         Email emailHandle;
         try {
-            // setting up email parameters
-            emailHandle = createEmailHandle(owner, ownerEmailIdList);
+            if (!emails.isEmpty()) {
+                // setting up email parameters
+                emailHandle = createEmailHandle(owner, emails);
 
-            // Setting up HTML thymeleaf email reply text
-            Map<String, Object> params = new HashMap<>();
-            params.put(DatabaseConstants.ANOMALIES, report);
-            params.put(Constants.EMAIL_HTML, "true");
-            ThymeleafTemplateEngine thymeleafTemplateEngine = new ThymeleafTemplateEngine();
-            if (report.get(0).getStatus().equals(Constants.WARNING)) {
-                // render the email HTML
-                String messageHtml = thymeleafTemplateEngine.render(new ModelAndView(params, "table"));
-                log.info("Thymeleaf rendered sunccessfully.");
-                emailHandle.setSubject("Sherlock: Anomaly report");
-                emailHandle.setTextHTML(messageHtml);
-                emailHandle.addHeader("X-Priority", 5);
+                // Setting up HTML thymeleaf email reply text
+                Map<String, Object> params = new HashMap<>();
+                params.put(DatabaseConstants.ANOMALIES, anomalyReports);
+                params.put(Constants.EMAIL_HTML, "true");
+                ThymeleafTemplateEngine thymeleafTemplateEngine = new ThymeleafTemplateEngine();
+                if (anomalyReports.size() > 0) {
+                    if (!(isNoDataCase(anomalyReports) || isErrorCase(anomalyReports))) {
+                        // render the email HTML
+                        String messageHtml = thymeleafTemplateEngine.render(new ModelAndView(params, "table"));
+                        log.info("Thymeleaf rendered sunccessfully.");
+                        emailHandle.setSubject("Sherlock: Anomaly report");
+                        emailHandle.setTextHTML(messageHtml);
+                        emailHandle.addHeader("X-Priority", 5);
+                    } else {
+                        // send error mail if job failed with error
+                        params.put(Constants.EMAIL_ERROR, "true");
+                        params.put(Constants.JOB_ID, anomalyReports.get(0).getJobId());
+                        params.put(Constants.TITLE, anomalyReports.get(0).getTestName());
+                        String messageHtml = thymeleafTemplateEngine.render(new ModelAndView(params, "table"));
+                        emailHandle.setSubject("Sherlock: Anomaly report ERROR");
+                        emailHandle.setTextHTML(messageHtml);
+                        emailHandle.addHeader("X-Priority", 5);
+                    }
+                } else {
+                    return true;
+                }
             } else {
-                // send error mail if job failed with error
-                params.put(Constants.EMAIL_ERROR, "true");
-                params.put(Constants.JOB_ID, report.get(0).getJobId());
-                params.put(Constants.TITLE, report.get(0).getTestName());
-                String messageHtml = thymeleafTemplateEngine.render(new ModelAndView(params, "table"));
-                emailHandle.setSubject("Sherlock: Anomaly report ERROR");
-                emailHandle.setTextHTML(messageHtml);
-                emailHandle.addHeader("X-Priority", 5);
+                return true;
             }
         } catch (Exception e) {
             log.error("Exception processing email body!", e);
             return false;
         }
         // send email
-        log.info("Sending email to " + owner + " on email ids: " + ownerEmailIdList);
+        log.info("Sending email to " + owner + " on email ids: " + emails);
         return sendFormattedEmail(emailHandle);
     }
 

--- a/src/main/java/com/yahoo/sherlock/settings/CLISettings.java
+++ b/src/main/java/com/yahoo/sherlock/settings/CLISettings.java
@@ -206,6 +206,18 @@ public class CLISettings {
     public static int HTTP_CLIENT_TIMEOUT = 20000;
 
     /**
+     * Backup redis DB local json dump file path.
+     */
+    @Parameter(names = "--backup-redis-db-path", description = "Backup redis DB local json dump file path. (default null i.e no backup)")
+    public static String BACKUP_REDIS_DB_PATH;
+
+    /**
+     * File path to specify the whitelisted druid broker hosts.
+     */
+    @Parameter(names = "--druid-brokers-list-file", description = "File to whitelist druid broker hosts. Format: <host1>:<port>,<host2>:<port>... (default null i.e any host is allowed)")
+    public static String DRUID_BROKERS_LIST_FILE;
+
+    /**
      * Parameters to ignore when printing fields.
      */
     private static String[] PRINT_IGNORED = {"log", "HELP", "REDIS_PASSWORD", "PRINT_IGNORED"};

--- a/src/main/java/com/yahoo/sherlock/settings/Constants.java
+++ b/src/main/java/com/yahoo/sherlock/settings/Constants.java
@@ -6,9 +6,23 @@
 
 package com.yahoo.sherlock.settings;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Constants for the project.
  */
+@Slf4j
 public final class Constants {
 
     /**
@@ -197,6 +211,11 @@ public final class Constants {
     public static final String COMMA_DELIMITER = ",";
 
     /**
+     * Delimiter constant for pipe.
+     */
+    public static final String PIPE_DELIMITER = "|";
+
+    /**
      * Delimiter constant for colon.
      */
     public static final String COLON_DELIMITER = ":";
@@ -290,4 +309,35 @@ public final class Constants {
      * Constant for 'http'.
      */
     public static final String HTTP = "http";
+
+    /**
+     * Constant for 'path'.
+     */
+    public static final String PATH = "path";
+
+    /**
+     * Constant set of allowed druid brokers.
+     */
+    public static final Set<String> VALID_DRUID_BROKERS;
+
+    static {
+        List<String> list;
+        // read allowed druid brokers from the file
+        if (CLISettings.DRUID_BROKERS_LIST_FILE != null) {
+            try (Stream<String> stream = Files.lines(Paths.get(CLISettings.DRUID_BROKERS_LIST_FILE))) {
+                list = stream
+                    .map(l -> l.replaceAll(WHITESPACE_REGEX, ""))
+                    .map(s -> Arrays.asList(s.split(COMMA_DELIMITER)))
+                    .flatMap(List::stream)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toList());
+            } catch (IOException e) {
+                log.error("Exception while reading druid brokers list file {}", CLISettings.DRUID_BROKERS_LIST_FILE, e);
+                list = new ArrayList<>();
+            }
+            VALID_DRUID_BROKERS = new HashSet<>(list);
+        } else {
+            VALID_DRUID_BROKERS = null;
+        }
+    }
 }

--- a/src/main/java/com/yahoo/sherlock/settings/DatabaseConstants.java
+++ b/src/main/java/com/yahoo/sherlock/settings/DatabaseConstants.java
@@ -72,6 +72,22 @@ public class DatabaseConstants {
      */
     public static final String INDEX_JOB_STATUS = "jobStatusIndex";
     /**
+     * The name and value of the email ID index parameter.
+     */
+    public static final String INDEX_EMAIL_ID = "emailIdIndex";
+    /**
+     * The name and value of the emailId-reports index parameter.
+     */
+    public static final String INDEX_EMAILID_REPORT = "emailIdReportsIndex";
+    /**
+     * The name and value of the email trigger index parameter.
+     */
+    public static final String INDEX_EMAILID_TRIGGER = "emailTriggerIndex";
+    /**
+     * The name and value of the email job index parameter.
+     */
+    public static final String INDEX_EMAILID_JOBID = "emailJobIndex";
+    /**
      * The name of the anomaly report field of anomaly timestamps.
      */
     public static final String ANOMALY_TIMESTAMP = "anomalyTimestamps";
@@ -110,6 +126,10 @@ public class DatabaseConstants {
      */
     public static final String REPORTS = "Reports";
     /**
+     * Database name for storing email ids.
+     */
+    public static final String EMAILS = "Emails";
+    /**
      * Database name for storing Headers(schema) for Serializers.
      */
     public static final String HEADERS = "Headers";
@@ -133,5 +153,16 @@ public class DatabaseConstants {
      * Atomic deletedJobId generator name.
      */
     public static final String DELETED_JOB_ID = "DeletedJobId";
-
+    /**
+     * Atomic emailId generator name.
+     */
+    public static final String EMAIL_ID = "emailId";
+    /**
+     * Constant for index.
+     */
+    public static final String INDEX = "Index";
+    /**
+     * Constant for deleted.
+     */
+    public static final String DELETED = "deleted";
 }

--- a/src/main/java/com/yahoo/sherlock/settings/QueryConstants.java
+++ b/src/main/java/com/yahoo/sherlock/settings/QueryConstants.java
@@ -30,4 +30,6 @@ public class QueryConstants {
     public static final String TYPE = "type";
     public static final String TIMEZONE = "timeZone";
     public static final String UTC = "UTC";
+    public static final String OUTPUT_NAME = "outputName";
+    public static final String UNKNOWN = "unknown";
 }

--- a/src/main/java/com/yahoo/sherlock/store/AnomalyReportAccessor.java
+++ b/src/main/java/com/yahoo/sherlock/store/AnomalyReportAccessor.java
@@ -28,9 +28,10 @@ public interface AnomalyReportAccessor {
      * report should be overridden. Usually, the ID should
      * have already been set based on the time series metric.
      * @param reports the anomaly report to insert
+     * @param emailIds list of EmailIDs to index the report ID in order to send it later to user
      * @throws IOException if an error occurs
      */
-    void putAnomalyReports(List<AnomalyReport> reports) throws IOException;
+    void putAnomalyReports(List<AnomalyReport> reports, List<String> emailIds) throws IOException;
 
     /**
      * Get a list of anomaly reports that have the specified job ID.
@@ -43,6 +44,17 @@ public interface AnomalyReportAccessor {
      */
     @NonNull
     List<AnomalyReport> getAnomalyReportsForJob(String jobId, String frequency) throws IOException;
+
+    /**
+     * Get a list of anomaly reports that are present in given emailId Index.
+     * This method should search the database for all anomaly reports
+     * present in the index of given emailId.
+     * @param emailId the emailId for which to find reports
+     * @return a list of associated reports, which may be empty
+     * @throws IOException if an error occurs
+     */
+    @NonNull
+    List<AnomalyReport> getAnomalyReportsForEmailId(String emailId) throws IOException;
 
     /**
      * Get a list of anomaly reports that have the specified job ID

--- a/src/main/java/com/yahoo/sherlock/store/EmailMetadataAccessor.java
+++ b/src/main/java/com/yahoo/sherlock/store/EmailMetadataAccessor.java
@@ -1,0 +1,83 @@
+package com.yahoo.sherlock.store;
+
+import com.yahoo.sherlock.exception.EmailNotFoundException;
+import com.yahoo.sherlock.model.EmailMetaData;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * The {@code EmailMetadataAccessor} defines an interface for
+ * communicating with a persistence layer, be it SQL, Redis, etc.,
+ * to retrieve and store {@code EmailMetadata} objects.
+ */
+public interface EmailMetadataAccessor {
+
+    /**
+     * Put the given {@code EmailMetadata} object in the store.
+     *
+     * @param emailMetaData           Object of EmailMetadata class to be stored
+     * @throws IOException            if there is an error with the persistence layer
+     */
+    void putEmailMetadata(EmailMetaData emailMetaData) throws IOException;
+
+    /**
+     * Put the new default {@code EmailMetadata} object if the emailId not present.
+     *
+     * @param emailId                 input emailId
+     * @param jobId                   jobId related to the email
+     * @throws IOException            if there is an error with the persistence layer
+     */
+    void putEmailMetadataIfNotExist(String emailId, String jobId) throws IOException;
+
+    /**
+     * Get the list of all {@code EmailMetadata} objects.
+     *
+     * @return the email metadata object list
+     * @throws IOException            if there is an error with the persistence layer
+     */
+    List<EmailMetaData> getAllEmailMetadata() throws IOException;
+
+    /**
+     * Get the {@code EmailMetadata} object with the specified emailId.
+     *
+     * @param emailId the emailId for which to retrieve the email metadata
+     * @return the email metadata with the specified emailId
+     * @throws IOException            if there is an error with the persistence layer
+     * @throws EmailNotFoundException if no email can be found with the specified ID
+     */
+    EmailMetaData getEmailMetadata(String emailId) throws IOException, EmailNotFoundException;
+
+    /**
+     * Get the list of all input emails that are present in instant Email index.
+     *
+     * @param emails list of input emails
+     * @return list of all input emails that are present in instant Email index
+     * @throws IOException            if there is an error with the persistence layer
+     */
+    List<String> checkEmailsInInstantIndex(List<String> emails) throws IOException;
+
+    /**
+     * Remove the emailid from the index of given trigger.
+     *
+     * @param emailId emailid
+     * @param trigger trigger name
+     * @throws IOException            if there is an error with the persistence layer
+     */
+    void removeFromTriggerIndex(String emailId, String trigger) throws IOException;
+
+    /**
+     * Get the list of all {@code EmailMetaData} objects in a given trigger index.
+     *
+     * @param trigger trigger name
+     * @return the email metadata object list
+     * @throws IOException            if there is an error with the persistence layer
+     */
+    List<EmailMetaData> getAllEmailMetadataByTrigger(String trigger) throws IOException;
+
+    /**
+     * Method to delete the email metadata object from all index and database.
+     * @param emailMetadata email metadata object to delete
+     */
+    void deleteEmailMetadata(EmailMetaData emailMetadata) throws IOException;
+}

--- a/src/main/java/com/yahoo/sherlock/store/JobMetadataAccessor.java
+++ b/src/main/java/com/yahoo/sherlock/store/JobMetadataAccessor.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.sherlock.store;
 
+import com.yahoo.sherlock.model.EmailMetaData;
 import com.yahoo.sherlock.model.JobMetadata;
 import com.yahoo.sherlock.exception.JobNotFoundException;
 
@@ -160,4 +161,16 @@ public interface JobMetadataAccessor {
      */
     void deleteJobs(Set<String> jobIds) throws IOException;
 
+    /**
+     * Method to delete given email from all related jobs.
+     * @param emailMetaData email metadata of emailId that is to be deleted
+     * @throws IOException if an error occurs
+     */
+    void deleteEmailFromJobs(EmailMetaData emailMetaData) throws IOException;
+
+    /**
+     * Method to save redis snapshot.
+     * @return OK
+     */
+    String saveRedisJobsMetadata() throws IOException;
 }

--- a/src/main/java/com/yahoo/sherlock/store/JsonDumper.java
+++ b/src/main/java/com/yahoo/sherlock/store/JsonDumper.java
@@ -29,7 +29,11 @@ public interface JsonDumper {
         DatabaseConstants.INDEX_JOB_CLUSTER_ID,
         DatabaseConstants.INDEX_JOB_ID,
         DatabaseConstants.INDEX_JOB_STATUS,
-        DatabaseConstants.INDEX_FREQUENCY
+        DatabaseConstants.INDEX_FREQUENCY,
+        DatabaseConstants.INDEX_EMAILID_REPORT,
+        DatabaseConstants.INDEX_EMAIL_ID,
+        DatabaseConstants.INDEX_EMAILID_TRIGGER,
+        DatabaseConstants.INDEX_EMAILID_JOBID
     };
 
     /**

--- a/src/main/java/com/yahoo/sherlock/store/Store.java
+++ b/src/main/java/com/yahoo/sherlock/store/Store.java
@@ -12,6 +12,7 @@ import com.yahoo.sherlock.settings.DatabaseConstants;
 import com.yahoo.sherlock.store.redis.LettuceAnomalyReportAccessor;
 import com.yahoo.sherlock.store.redis.LettuceDeletedJobMetadataAccessor;
 import com.yahoo.sherlock.store.redis.LettuceDruidClusterAccessor;
+import com.yahoo.sherlock.store.redis.LettuceEmailMetadataAccessor;
 import com.yahoo.sherlock.store.redis.LettuceJobMetadataAccessor;
 import com.yahoo.sherlock.store.redis.LettuceJobScheduler;
 import com.yahoo.sherlock.store.redis.LettuceJsonDumper;
@@ -37,6 +38,7 @@ public class Store {
         DELETED_JOB_METADATA,
         DRUID_CLUSTER,
         JOB_METADATA,
+        EMAIL_METADATA,
         JSON_DUMPER,
         JOB_SCHEDULER
     }
@@ -57,6 +59,10 @@ public class Store {
      * Active job metadata accessor instance.
      */
     private static JobMetadataAccessor jobMetadataAccessor = null;
+    /**
+     * Active email metadata scheduler instance.
+     */
+    private static EmailMetadataAccessor emailMetadataAccessor = null;
     /**
      * Active json dumper instance.
      */
@@ -88,9 +94,13 @@ public class Store {
                 put(DatabaseConstants.INDEX_QUERY_ID, DatabaseConstants.INDEX_QUERY_ID);
                 put(DatabaseConstants.INDEX_JOB_ID, DatabaseConstants.INDEX_JOB_ID);
                 put(DatabaseConstants.INDEX_FREQUENCY, DatabaseConstants.INDEX_FREQUENCY);
+                put(DatabaseConstants.INDEX_EMAILID_REPORT, DatabaseConstants.INDEX_EMAILID_REPORT);
+                put(DatabaseConstants.INDEX_EMAILID_TRIGGER, DatabaseConstants.INDEX_EMAILID_TRIGGER);
+                put(DatabaseConstants.INDEX_EMAILID_JOBID, DatabaseConstants.INDEX_EMAILID_JOBID);
                 put(DatabaseConstants.INDEX_JOB_CLUSTER_ID, DatabaseConstants.INDEX_JOB_CLUSTER_ID);
                 put(DatabaseConstants.INDEX_JOB_STATUS, DatabaseConstants.INDEX_JOB_STATUS);
                 put(DatabaseConstants.QUEUE_JOB_SCHEDULE, DatabaseConstants.QUEUE_JOB_SCHEDULE);
+                put(DatabaseConstants.INDEX_EMAIL_ID, DatabaseConstants.INDEX_EMAIL_ID);
             }
         };
         String dbName;
@@ -107,6 +117,10 @@ public class Store {
             case DRUID_CLUSTER:
                 dbName = DatabaseConstants.DRUID_CLUSTERS;
                 idName = DatabaseConstants.CLUSTER_ID;
+                break;
+            case EMAIL_METADATA:
+                dbName = DatabaseConstants.EMAILS;
+                idName = DatabaseConstants.EMAIL_ID;
                 break;
             case JOB_METADATA:
             default:
@@ -142,6 +156,8 @@ public class Store {
                 return new LettuceJobScheduler(params);
             case JSON_DUMPER:
                 return new LettuceJsonDumper(params);
+            case EMAIL_METADATA:
+                return new LettuceEmailMetadataAccessor(params);
             default:
                 return null;
         }
@@ -219,4 +235,14 @@ public class Store {
         return jobScheduler;
     }
 
+    /**
+     * @return the email metadata accessor instance
+     */
+    public static EmailMetadataAccessor getEmailMetadataAccessor() {
+        if (emailMetadataAccessor == null) {
+            emailMetadataAccessor =
+                    (EmailMetadataAccessor) initializeAccessor(AccessorType.EMAIL_METADATA);
+        }
+        return emailMetadataAccessor;
+    }
 }

--- a/src/main/java/com/yahoo/sherlock/store/core/AsyncCommands.java
+++ b/src/main/java/com/yahoo/sherlock/store/core/AsyncCommands.java
@@ -35,6 +35,14 @@ public interface AsyncCommands<K> extends AutoCloseable {
 
     /**
      * @param key key to get
+     * @param value value of the key
+     * @return Ok if set the key
+     * @see com.lambdaworks.redis.api.async.RedisAsyncCommands#set(Object, Object)
+     */
+    RedisFuture<String> set(K key, K value);
+
+    /**
+     * @param key key to get
      * @return value of the key
      * @see com.lambdaworks.redis.api.async.RedisAsyncCommands#get(Object)
      */
@@ -115,6 +123,12 @@ public interface AsyncCommands<K> extends AutoCloseable {
      * @return true if expiration is set else false
      */
     RedisFuture<Boolean> expire(K key, long seconds);
+
+    /**
+     * Command to dump snapshot of redis data.
+     * @return OK string
+     */
+    RedisFuture<String> bgsave();
 
     @Override
     void close();

--- a/src/main/java/com/yahoo/sherlock/store/core/AsyncCommandsClusterImpl.java
+++ b/src/main/java/com/yahoo/sherlock/store/core/AsyncCommandsClusterImpl.java
@@ -40,6 +40,11 @@ public class AsyncCommandsClusterImpl<K> implements AsyncCommands<K> {
     }
 
     @Override
+    public RedisFuture<String> set(K key, K value) {
+        return commands.set(key, value);
+    }
+
+    @Override
     public RedisFuture<K> get(K key) {
         return commands.get(key);
     }
@@ -97,5 +102,10 @@ public class AsyncCommandsClusterImpl<K> implements AsyncCommands<K> {
     @Override
     public void close() {
         commands.close();
+    }
+
+    @Override
+    public RedisFuture<String> bgsave() {
+        return commands.bgsave();
     }
 }

--- a/src/main/java/com/yahoo/sherlock/store/core/AsyncCommandsImpl.java
+++ b/src/main/java/com/yahoo/sherlock/store/core/AsyncCommandsImpl.java
@@ -40,6 +40,11 @@ public class AsyncCommandsImpl<K> implements AsyncCommands<K> {
     }
 
     @Override
+    public RedisFuture<String> set(K key, K value) {
+        return commands.set(key, value);
+    }
+
+    @Override
     public RedisFuture<K> get(K key) {
         return commands.get(key);
     }
@@ -97,5 +102,10 @@ public class AsyncCommandsImpl<K> implements AsyncCommands<K> {
     @Override
     public void close() {
         commands.close();
+    }
+
+    @Override
+    public RedisFuture<String> bgsave() {
+        return commands.bgsave();
     }
 }

--- a/src/main/java/com/yahoo/sherlock/store/core/SyncCommands.java
+++ b/src/main/java/com/yahoo/sherlock/store/core/SyncCommands.java
@@ -16,6 +16,21 @@ import java.util.Set;
 public interface SyncCommands<K> extends AutoCloseable {
 
     /**
+     * @param key key to get
+     * @param value value of the key
+     * @return Ok if set the key
+     * @see com.lambdaworks.redis.api.sync.RedisCommands#set(Object, Object)
+     */
+    String set(K key, K value);
+
+    /**
+     * @param key key to get
+     * @return value of the key
+     * @see com.lambdaworks.redis.api.sync.RedisCommands#get(Object)
+     */
+    K get(K key);
+
+    /**
      * @param key long key to increment
      * @return value before increment
      * @see com.lambdaworks.redis.api.sync.RedisCommands#incr(Object)
@@ -107,6 +122,12 @@ public interface SyncCommands<K> extends AutoCloseable {
      * @return true if expiration is set else false
      */
     Boolean expire(K key, long seconds);
+
+    /**
+     * Command to dump snapshot of redis data.
+     * @return OK string
+     */
+    String bgsave();
 
     @Override
     void close();

--- a/src/main/java/com/yahoo/sherlock/store/core/SyncCommandsClusterImpl.java
+++ b/src/main/java/com/yahoo/sherlock/store/core/SyncCommandsClusterImpl.java
@@ -26,6 +26,16 @@ public class SyncCommandsClusterImpl<K> implements SyncCommands<K> {
     }
 
     @Override
+    public String set(K key, K value) {
+        return commands.set(key, value);
+    }
+
+    @Override
+    public K get(K key) {
+        return commands.get(key);
+    }
+
+    @Override
     public Long incr(K key) {
         return commands.incr(key);
     }
@@ -89,4 +99,10 @@ public class SyncCommandsClusterImpl<K> implements SyncCommands<K> {
     public void close() {
         commands.close();
     }
+
+    @Override
+    public String bgsave() {
+        return commands.bgsave();
+    }
+
 }

--- a/src/main/java/com/yahoo/sherlock/store/core/SyncCommandsImpl.java
+++ b/src/main/java/com/yahoo/sherlock/store/core/SyncCommandsImpl.java
@@ -26,6 +26,16 @@ public class SyncCommandsImpl<K> implements SyncCommands<K> {
     }
 
     @Override
+    public String set(K key, K value) {
+        return commands.set(key, value);
+    }
+
+    @Override
+    public K get(K key) {
+        return commands.get(key);
+    }
+
+    @Override
     public Long incr(K key) {
         return commands.incr(key);
     }
@@ -82,11 +92,16 @@ public class SyncCommandsImpl<K> implements SyncCommands<K> {
 
     @Override
     public Boolean expire(K key, long seconds) {
-        return commands.expire(key, seconds);
+        return expire(key, seconds);
     }
 
     @Override
     public void close() {
         commands.close();
+    }
+
+    @Override
+    public String bgsave() {
+        return commands.bgsave();
     }
 }

--- a/src/main/java/com/yahoo/sherlock/store/redis/LettuceEmailMetadataAccessor.java
+++ b/src/main/java/com/yahoo/sherlock/store/redis/LettuceEmailMetadataAccessor.java
@@ -1,0 +1,230 @@
+package com.yahoo.sherlock.store.redis;
+
+import com.lambdaworks.redis.RedisFuture;
+import com.yahoo.sherlock.enums.Triggers;
+import com.yahoo.sherlock.exception.EmailNotFoundException;
+import com.yahoo.sherlock.model.EmailMetaData;
+import com.yahoo.sherlock.settings.DatabaseConstants;
+import com.yahoo.sherlock.store.EmailMetadataAccessor;
+import com.yahoo.sherlock.store.StoreParams;
+import com.yahoo.sherlock.store.core.AsyncCommands;
+import com.yahoo.sherlock.store.core.RedisConnection;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Email metadata accessor implemented for clusters with lettuce.
+ */
+@Slf4j
+public class LettuceEmailMetadataAccessor extends AbstractLettuceAccessor implements EmailMetadataAccessor {
+
+    private final String emailIdIndex;
+    private final String emailTriggerIndex;
+    private final String emailJobIndex;
+
+    /**
+     * @param params store parameters
+     */
+    public LettuceEmailMetadataAccessor(StoreParams params) {
+        super(params);
+        this.emailIdIndex = params.get(DatabaseConstants.INDEX_EMAIL_ID);
+        this.emailTriggerIndex = params.get(DatabaseConstants.INDEX_EMAILID_TRIGGER);
+        this.emailJobIndex = params.get(DatabaseConstants.INDEX_EMAILID_JOBID);
+    }
+
+    @Override
+    public void putEmailMetadata(EmailMetaData emailMetaData) throws IOException {
+        log.info("Putting Email metadata with ID [{}]", emailMetaData.getEmailId());
+        String emailId = emailMetaData.getEmailId();
+        try (RedisConnection<String> conn = connect()) {
+            if (emailId != null && !emailId.isEmpty()) {
+                AsyncCommands<String> cmd = conn.async();
+                cmd.setAutoFlushCommands(false);
+                RedisFuture[] futures = {
+                    cmd.hmset(key(emailMetaData.getEmailId()), map(emailMetaData)),
+                    cmd.sadd(index(emailIdIndex, DatabaseConstants.EMAILS), emailId)
+                };
+                cmd.flushCommands();
+                await(futures);
+                RedisFuture<Long> futureIndex;
+                String interval = emailMetaData.getRepeatInterval();
+                futureIndex = cmd.sadd(index(emailTriggerIndex, interval), emailId);
+                cmd.flushCommands();
+                await(futureIndex);
+                log.info("Added emailId:{} to {} index", emailId, interval);
+                log.info("Successfully added new Email ID [{}]", emailId);
+            } else {
+                log.error("Email ID can not be null or empty! value: {}!", emailId);
+            }
+        }
+    }
+
+    @Override
+    public void putEmailMetadataIfNotExist(String emailId, String jobId) throws IOException {
+        log.info("Putting Email with ID [{}] if not already exist", emailId);
+        try (RedisConnection<String> conn = connect()) {
+            if (emailId != null) {
+                AsyncCommands<String> cmd = conn.async();
+                cmd.setAutoFlushCommands(false);
+                RedisFuture<Long> checkIndex = cmd.sadd(index(emailIdIndex, DatabaseConstants.EMAILS), emailId);
+                RedisFuture<Long> jobEmailIndex = cmd.sadd(index(emailJobIndex, emailId), jobId);
+                cmd.flushCommands();
+                await(checkIndex, jobEmailIndex);
+                if (checkIndex.get() != 0L) {
+                    putEmailMetadata(new EmailMetaData(emailId));
+                } else {
+                    log.info("[{}] already exist", emailId);
+                }
+            } else {
+                log.error("Email ID can not be null!");
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Error occurred while deleting job!", e);
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<EmailMetaData> getAllEmailMetadata() throws IOException {
+        log.info("Getting metadata for all emails");
+        try (RedisConnection<String> conn = connect()) {
+            AsyncCommands<String> cmd = conn.async();
+            cmd.setAutoFlushCommands(false);
+            RedisFuture<Set<String>> emailFutureList = cmd.smembers(index(emailIdIndex, DatabaseConstants.EMAILS));
+            cmd.flushCommands();
+            await(emailFutureList);
+            Set<String> emailList = emailFutureList.get();
+            List<RedisFuture<Map<String, String>>> values = new ArrayList<>(emailList.size());
+            log.info("Fetching metadata for {} emails", emailList.size());
+            for (String emailId : emailList) {
+                values.add(cmd.hgetall(key(emailId)));
+            }
+            cmd.flushCommands();
+            await(values);
+            List<EmailMetaData> emailMetaDataList = new ArrayList<>(values.size());
+            for (RedisFuture<Map<String, String>> value : values) {
+                emailMetaDataList.add(unmap(EmailMetaData.class, value.get()));
+            }
+            return emailMetaDataList;
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Error occurred while getting emails metadata!", e);
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public EmailMetaData getEmailMetadata(String emailId) throws IOException, EmailNotFoundException {
+        log.info("Getting metadata for email {}", emailId);
+        try (RedisConnection<String> conn = connect()) {
+            AsyncCommands<String> cmd = conn.async();
+            cmd.setAutoFlushCommands(false);
+            RedisFuture<Map<String, String>> value = cmd.hgetall(key(emailId));
+            cmd.flushCommands();
+            await(value);
+            if (value.get() != null && value.get().isEmpty()) {
+                throw new EmailNotFoundException(emailId);
+            }
+            return unmap(EmailMetaData.class, value.get());
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Error occurred while getting emails metadata!", e);
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<String> checkEmailsInInstantIndex(List<String> emails) throws IOException {
+        log.info("Checking for emails in Instant index");
+        try (RedisConnection<String> conn = connect()) {
+            AsyncCommands<String> cmd = conn.async();
+            cmd.setAutoFlushCommands(false);
+            RedisFuture<Set<String>> future = cmd.smembers(index(emailTriggerIndex, Triggers.INSTANT.toString()));
+            cmd.flushCommands();
+            await(future);
+            List<String> result = new ArrayList<>();
+            Set<String> instantList = future.get();
+            for (String email : emails) {
+                if (instantList.contains(email)) {
+                    result.add(email);
+                }
+            }
+            return result;
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Error occurred while getting instant email index!", e);
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void removeFromTriggerIndex(String emailId, String trigger) throws IOException {
+        log.info("Removing {} from email trigger {} index", emailId, trigger);
+        try (RedisConnection<String> conn = connect()) {
+            AsyncCommands<String> cmd = conn.async();
+            cmd.setAutoFlushCommands(false);
+            RedisFuture<Long> future = cmd.srem(index(emailTriggerIndex, trigger), emailId);
+            cmd.flushCommands();
+            await(future);
+            log.info("Removed {} from index. redis response: {}", emailId, future.get().toString());
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Error occurred while getting instant email index!", e);
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<EmailMetaData> getAllEmailMetadataByTrigger(String trigger) throws IOException {
+        log.info("Getting metadata for all emails for trigger {}", trigger);
+        try (RedisConnection<String> conn = connect()) {
+            AsyncCommands<String> cmd = conn.async();
+            cmd.setAutoFlushCommands(false);
+            RedisFuture<Set<String>> emailFutureList = cmd.smembers(index(emailTriggerIndex, trigger));
+            cmd.flushCommands();
+            await(emailFutureList);
+            Set<String> emailList = emailFutureList.get();
+            List<RedisFuture<Map<String, String>>> values = new ArrayList<>(emailList.size());
+            log.info("Fetching metadata for {} emails", emailList.size());
+            for (String emailId : emailList) {
+                values.add(cmd.hgetall(key(emailId)));
+            }
+            cmd.flushCommands();
+            await(values);
+            List<EmailMetaData> emailMetaDataList = new ArrayList<>(values.size());
+            for (RedisFuture<Map<String, String>> value : values) {
+                emailMetaDataList.add(unmap(EmailMetaData.class, value.get()));
+            }
+            return emailMetaDataList;
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Error occurred while getting emails metadata!", e);
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void deleteEmailMetadata(EmailMetaData emailMetadata) throws IOException {
+        String emailId = emailMetadata.getEmailId();
+        String trigger = emailMetadata.getRepeatInterval();
+        log.info("Deleting email {}", emailId);
+        try (RedisConnection<String> conn = connect()) {
+            AsyncCommands<String> cmd = conn.async();
+            cmd.setAutoFlushCommands(false);
+            RedisFuture[] emailIndexFutureList = new RedisFuture[] {
+                cmd.srem(index(emailTriggerIndex, trigger), emailId),
+                cmd.srem(index(emailIdIndex, DatabaseConstants.EMAILS), emailId),
+                cmd.del(index(DatabaseConstants.INDEX_EMAILID_REPORT, emailId)),
+                cmd.del(key(emailId))
+            };
+            cmd.flushCommands();
+            await(emailIndexFutureList);
+            log.info("Succesfully deleted email {}", emailId);
+        } catch (Exception e) {
+            log.error("Error occurred while deleting emails metadata!", e);
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/yahoo/sherlock/utils/BackupUtils.java
+++ b/src/main/java/com/yahoo/sherlock/utils/BackupUtils.java
@@ -1,0 +1,51 @@
+package com.yahoo.sherlock.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.stream.JsonReader;
+import com.yahoo.sherlock.settings.CLISettings;
+import com.yahoo.sherlock.store.JsonDumper;
+import com.yahoo.sherlock.store.Store;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Back Util class for redis json dump.
+ */
+@Slf4j
+public class BackupUtils {
+
+    /* Gson object */
+    private static Gson gson = new Gson();
+
+    /**
+     * Method to backup redis data into a file at {@link CLISettings#BACKUP_REDIS_DB_PATH}.
+     * @throws IOException IO exception
+     */
+    public static void startBackup() throws IOException {
+        JsonDumper jsonDumper = Store.getJsonDumper();
+        JsonObject jsonObject = jsonDumper.getRawData();
+        try (FileWriter file = new FileWriter(CLISettings.BACKUP_REDIS_DB_PATH)) {
+            file.write(gson.toJson(jsonObject));
+            file.close();
+            log.info("Successfully wrote redis data to json file");
+        }
+    }
+
+    /**
+     * Method to read data from backup file.
+     * @param path full system path to the file
+     * @return redis data as json object
+     * @throws FileNotFoundException exception if file not found
+     */
+    public static JsonObject getDataFromJsonFile(String path) throws FileNotFoundException {
+        JsonReader reader = new JsonReader(new FileReader(path));
+        JsonObject jsonObject = gson.fromJson(reader, JsonObject.class);
+        return jsonObject;
+    }
+}

--- a/src/main/resources/templates/emailInfo.html
+++ b/src/main/resources/templates/emailInfo.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="fragments/head :: head"></head>
+
+<body>
+<!-- Wrapper -->
+<div id="wrapper">
+    <!-- Sidebar -->
+    <div id="sidebar-wrapper" th:replace="fragments/nav :: nav"></div>
+    <!-- #Sidebar -->
+
+    <!-- Page Content -->
+    <div id="page-content-wrapper">
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-lg-12">
+                    <h1 th:text="${title}">TITLE</h1>
+                    <div th:if="${error != null}" th:text="${error}" class="alert alert-danger" role="alert">Error message</div>
+                    <form id="emailForm" method='post'>
+                        <fieldset>
+                            <div class="form-group">
+                                <label class="control-label" for="emailId">Email Id:</label>
+                                <div>
+                                    <input id="emailId" name="emailId" type="text"
+                                           class="form-control input-md" size="25" required="true"
+                                           disabled="true" th:value="${email.getEmailId()}" />
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label class="control-label" for="sendOutHour">Send Out Hour(0-23):</label>
+                                <div>
+                                    <input id="sendOutHour" name="sendOutHour" type="number"
+                                           class="form-control input-md" size="25" th:value="${email.getSendOutHour()}" max="23" th:required="true" onchange="updateMetadata()"/>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label class="control-label" for="sendOutMinute">Send Out Minute(0-59):</label>
+                                <div>
+                                    <input id="sendOutMinute" name="sendOutMinute" type="number"
+                                           class="form-control input-md" size="25" th:value="${email.getSendOutMinute()}" max="59" th:required="true" onchange="updateMetadata()"/>
+                                </div>
+                            </div>
+                            <div class="form-group" id="triggerSection">
+                                <label class="control-label" for="trigger">Trigger Interval:</label>
+                                <p id="defaultTriggerMsg" class="bg-info">Select the trigger interval to send out email .
+                                    <code>Default: 'instant' i.e. as soon as report is available</code></p>
+                                <div>
+                                    <select id="trigger" name="trigger" class="form-control"
+                                            th:field="*{emailTriggers}" th:required="true" onchange="updateMetadata()">
+                                        <option th:each="trigger : ${emailTriggers}"
+                                                th:value="${trigger}"
+                                                th:selected="${trigger} == ${email.getRepeatInterval()} ? true : false"
+                                                th:text="${trigger}"></option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div id="updateActions" class="form-group">
+                                <label class="control-label" for="submit">Action:</label>
+                                <div>
+                                    <!--Show update button for update-->
+                                    <span id="updateButton">
+                                        <input id="submit" type="submit" class="btn btn-success" value="Update" disabled="true"/>
+                                    </span>
+                                    <!--Show cancel button to cancel-->
+                                    <span id="cancelButton" hidden="true">
+                                        <div id="cancel" class="btn btn-danger" onclick="backToEmailInfo()">Cancel</div>
+                                    </span>
+                                    <!--Show delete button to delete-->
+                                    <span id="deleteButton">
+                                        <div id="delete" class="btn btn-danger" onclick="deleteEmail()">Delete</div>
+                                    </span>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<script language="javascript" type="text/javascript" th:inline="javascript">
+/*<![CDATA[*/
+	$(document).ready(function() {
+		if ([[${email.getRepeatInterval()}]] === 'instant') {
+            $('#sendOutHour').attr("disabled", true);
+            $('#sendOutMinute').attr("disabled", true);
+		} else if([[${email.getRepeatInterval()}]] === 'hour') {
+            $('#sendOutHour').attr("disabled", true);
+            $('#sendOutMinute').attr("disabled", false);
+		}
+		$('#submit').attr("disabled", true);
+	});
+
+	$("#emailForm").submit(function(e) {
+        e.preventDefault();
+        var data = {};
+        data.emailId = $('#emailId').val();
+        data.sendOutHour = $('#sendOutHour').val();
+        data.sendOutMinute = $('#sendOutMinute').val();
+        data.repeatInterval = $('#trigger').val();
+        $.ajax({
+            type: 'POST',
+            url: '/Emails/' + $('#emailId').val(),
+            data: JSON.stringify(data),
+            contentType: "application/json",
+            dataType: 'text',
+            success: function (response, status, jQxhr) {
+                if (status === 'success') {
+                    showInfoMessage("Email info updated successfully.");
+                    setTimeout(function() {
+                        window.location.href = '/Emails/' + response;
+                    }, 1500);
+                } else {
+                    showErrorMessage("Something went wrong in updating email info! Try again.");
+                }
+            },
+            error : ajaxMessage
+        });
+        return;
+    });
+
+    $('#sendOutHour').on('input', function() {
+        updateMetadata();
+    });
+
+    $('#sendOutMinute').on('input', function() {
+        updateMetadata();
+    });
+
+    function updateMetadata() {
+        if ($('#trigger').val() === 'instant') {
+            $('#sendOutHour').attr("disabled", true);
+            $('#sendOutMinute').attr("disabled", true);
+		} else if($('#trigger').val() === 'hour') {
+            $('#sendOutMinute').attr("disabled", false);
+            $('#sendOutHour').attr("disabled", true);
+		} else {
+		    $('#sendOutHour').attr("disabled", false);
+            $('#sendOutMinute').attr("disabled", false);
+        }
+		$('#submit').attr("disabled", false);
+        $('#cancelButton').attr("hidden", false);
+        $('#deleteButton').attr("hidden", true);
+    }
+
+    function backToEmailInfo() {
+        window.location.href = '/Emails/' + $('#emailId').val();
+    }
+
+    function deleteEmail() {
+        $.ajax({
+            type: 'POST',
+            url: '/DeleteEmail/' + $('#emailId').val(),
+            contentType: "application/json",
+            dataType: 'text',
+            success: function (response, status, jQxhr) {
+                if (status === 'success') {
+                    showInfoMessage("Email info updated successfully.");
+                    setTimeout(function() {
+                        window.location.href = '/Meta-Manager';
+                    }, 1500);
+                } else {
+                    showErrorMessage("Something went wrong while deleting email! Try again.");
+                }
+            },
+            error : ajaxMessage
+        });
+        return;
+    }
+
+/*]]>*/
+</script>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -80,6 +80,6 @@
 	<link href="/css/bootstrap-tokenfield.min.css" rel="stylesheet"/>
 	<script src="/js/bootstrap-tokenfield.min.js"></script>
 	<!-- Include the multiselect plugin's CSS and JS: -->
-	<script type="text/javascript" src="/js/bootstrap-multiselect.js"></script>
-	<link rel="stylesheet" href="/css/bootstrap-multiselect.css" type="text/css"/>
+	<script src="/js/bootstrap-multiselect.js"></script>
+	<link rel="stylesheet" href="/css/bootstrap-multiselect.css"/>
 </head>

--- a/src/main/resources/templates/jobForm.html
+++ b/src/main/resources/templates/jobForm.html
@@ -50,7 +50,7 @@
                                 <div>
                                     <input type="text"  id="owner-email" name="owner-email"
                                            placeholder="Enter the email[s] and hit enter"
-                                           class="form-control input-md" required="true"/>
+                                           class="form-control input-md"/>
                                 </div>
                             </div>
 

--- a/src/main/resources/templates/jobInfo.html
+++ b/src/main/resources/templates/jobInfo.html
@@ -66,7 +66,7 @@
                                 <label class="control-label" for="ownerEmail">Owner's Email (for anomaly alerts):</label>
                                 <div>
                                     <input id="ownerEmail" name="ownerEmail" type="text" class="form-control input-md"
-                                           size="25" th:value="${job.getOwnerEmail()}" th:required="true"/>
+                                           size="25" th:value="${job.getOwnerEmail()}"/>
                                 </div>
                             </div>
 

--- a/src/main/resources/templates/redisRestoreForm.html
+++ b/src/main/resources/templates/redisRestoreForm.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments/head :: head"></head>
+<body>
+<div id="wrapper">
+    <div id="sidebar-wrapper" th:replace="fragments/nav :: nav"></div>
+    <div id="page-content-wrapper">
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-lg-12">
+                    <h1>Restore Redis Data:</h1>
+                    <form id="queryForm" method="post">
+                        <fieldset>
+
+                            <div class="form-group">
+                                <label class="control-label" for="path">Full Path to Backup file:</label><br/>
+                                <div>
+                                    <input id="path" name="path" type="text"
+                                           placeholder="Enter full path to redis json dump" class="form-control input-md"
+                                           size="25" th:required="true" th:autofocus="true"/>
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <input id="submit" type="submit" class="btn btn-success" value="Restore"/>
+                            </div>
+
+                        </fieldset>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- save confirmation -->
+<div id="saveConfirmModal" class="modal fade" role="dialog">
+    <div class="modal-dialog">
+        <!-- Modal content-->
+        <div class="modal-content">
+            <div class="modal-body">
+                <p id="saveConfirmModalCode">Are you sure? this is going to stop all running jobs if any!</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" data-dismiss="modal" class="btn btn-primary" id="saveConfirmModalYes">Yes
+                </button>
+                <button type="button" data-dismiss="modal" class="btn" id="saveConfirmModalNo">No</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+
+/*<![CDATA[*/
+    $(document).ready(function () {
+        $("#queryForm").submit(function (e) {
+            e.preventDefault();
+            $('#saveConfirmModalCode').html();
+            $('#saveConfirmModal').modal('show');
+        });
+    });
+
+    $("#saveConfirmModalYes").click(function () {
+        var data = {};
+        data.path = $('#path').val();
+        $.ajax({
+            type: 'POST',
+            url: '/Debug/Restore',
+            data: JSON.stringify(data),
+            contentType: "application/json",
+            dataType: 'text',
+            success: function (response) {
+                if ($.isEmptyObject(response)) {
+                    showWarningMessage("Something went wrong! Try again.");
+                } else {
+                    showInfoMessage("Redis data ingested successfully!");
+                    //setTimeout(function () {
+                    //    window.location.href = '/';
+                    //}, 1000);
+                }
+            },
+            error: ajaxMessage
+        });
+    });
+/*]]>*/
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -69,6 +69,33 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="form-group">
+                                <div class="panel panel-default">
+                                    <div class="panel-heading">
+                                        <h3 class="panel-title">Email Manager</h3>
+                                    </div>
+                                    <div class="panel-body">
+                                        <table id="emailTable" class="table table-striped table-hover table-bordered">
+                                            <thead>
+                                                <tr>
+                                                    <th>Email ID</th>
+                                                    <th>Send out Hour</th>
+                                                    <th>Send out Minute</th>
+                                                    <th>Interval</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr th:each="email: ${emails}" class='clickable-row' th:attr="data-href=${'/Emails/' + email.getEmailId()}">
+                                                    <td th:text="${email.getEmailId()}">email</td>
+                                                    <td th:text="${email.getSendOutHour()}">hour</td>
+                                                    <td th:text="${email.getSendOutMinute()}">minute</td>
+                                                    <td th:text="${email.getRepeatInterval()}">interval</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
                         </fieldset>
                     </form>
                 </div>

--- a/src/main/resources/templates/static/js/calendar-heatmap.js
+++ b/src/main/resources/templates/static/js/calendar-heatmap.js
@@ -28,8 +28,8 @@ function calendarHeatmap() {
     var SQUARE_LENGTH = 16;
     var SQUARE_PADDING = 3;
     var legendSpacing = 7;
-    var MONTH_LABEL_PADDING = 6;
-    var DAY_LABEL_PADDING = 6;
+    var MONTH_LABEL_PADDING = 19;
+    var DAY_LABEL_PADDING = 19;
     var HEATMAP_PADDING = 45
     var data = [];
     var max = null;
@@ -185,16 +185,18 @@ function calendarHeatmap() {
         // Draw the minute chart
         function drawMinuteChart() {
 
-            height = 7 * (SQUARE_LENGTH + SQUARE_PADDING) + 3;
+            v_legendSpacing = 82;
+            height = 10 * (SQUARE_LENGTH + SQUARE_PADDING);
+            width = v_legendSpacing + width;
 
             var svg = d3.select(chart.selector())
                 .style('position', 'relative')
                 .append('svg')
-                .attr('transform', 'translate(0,0)')
+                .attr('transform', 'translate(-60,0)')
                 .attr('width', width)
                 .attr('class', 'calendar-heatmap')
                 .attr('height', height)
-                .style('padding', '71px');
+                .style('padding', '20px');
 
             minuteRects = svg.selectAll('.cell')
                 .data(sixHoursRange);
@@ -207,7 +209,7 @@ function calendarHeatmap() {
                 .attr('x', function (d, i) {
                     var cellDate = moment.utc(d);
                     var result = (cellDate.minute() % 60) * (SQUARE_LENGTH + SQUARE_PADDING);
-                    return result + 10;
+                    return result + v_legendSpacing;
                 })
                 .attr('y', function (d, i) {
                     var cellDate = moment.utc(d);
@@ -236,7 +238,7 @@ function calendarHeatmap() {
                         .attr('class', 'cell-tooltip')
                         .html(tooltipHTMLForDate(d))
                         .style('left', function () {
-                            return (cellDate.minute() % 60) * (SQUARE_LENGTH) + 'px';
+                            return (cellDate.minute() % 60) * (SQUARE_LENGTH) + v_legendSpacing + 'px';
                         })
                         .style('top', function () {
                             var cellDate = moment.utc(d);
@@ -268,15 +270,15 @@ function calendarHeatmap() {
                     .attr('class', 'calendar-heatmap-legend')
                     .attr('width', SQUARE_LENGTH)
                     .attr('height', SQUARE_LENGTH)
-                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + 10; })
-                    .attr('y', height + SQUARE_PADDING + SQUARE_LENGTH)
+                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + v_legendSpacing; })
+                    .attr('y', height - (SQUARE_PADDING + SQUARE_LENGTH))
                     .attr('fill', function (d) { return d.value; });
 
                 legendGroup.append('text')
                     .attr('class', 'calendar-heatmap-legend-text calendar-heatmap-legend-text-less')
                     .text(function(d) { return (d.key === 'warning' ? locale.Anomaly : (d.key === 'success' ? locale.NoAnomaly : (d.key === 'error' ? locale.Error : (d.key === 'nodata' ? locale.NoData : locale.defaultMsg)))); })
-                    .attr('x', function (d, i) { return ((SQUARE_LENGTH + SQUARE_PADDING) * (1 + i * legendSpacing)) + 10; })
-                    .attr('y', height + 2 * SQUARE_LENGTH)
+                    .attr('x', function (d, i) { return ((SQUARE_LENGTH + SQUARE_PADDING) * (1 + i * legendSpacing)) + v_legendSpacing; })
+                    .attr('y', height - 2 * SQUARE_PADDING)
             }
 
             var minuteRange = Array.apply(null, {length: 60}).map(Number.call, Number);
@@ -290,16 +292,16 @@ function calendarHeatmap() {
                     return d;
                 })
                 .attr('x', function (d, i) {
-                    return (d % 60) * (SQUARE_LENGTH + SQUARE_PADDING) + 10;
+                    return (d % 60) * (SQUARE_LENGTH + SQUARE_PADDING) + v_legendSpacing;
                 })
-                .attr('y', 0)
+                .attr('y', SQUARE_LENGTH - SQUARE_PADDING)
                 .style('fill', function (d) { return d % 2 === 0 ? '#ff0000' : 'white';});
 
             hourRange.forEach(function (date, index) {
                 var dateformat = 'MMM DD, HH a';
                 svg.append('text')
                     .attr('class', 'day-initial')
-                    .attr('transform', 'translate(-71,' + (((SQUARE_LENGTH + SQUARE_PADDING) * (index + 1)) - SQUARE_PADDING) + ')')
+                    .attr('transform', 'translate(0,' + (((SQUARE_LENGTH + SQUARE_PADDING) * (index + 1)) + (SQUARE_LENGTH - SQUARE_PADDING)) + ')')
                     .style('text-anchor', 'left')
                     .attr('dy', '2')
                     .text(moment.utc(date).format(dateformat));
@@ -314,9 +316,9 @@ function calendarHeatmap() {
 
             function minutePath(d) {
                 var size = SQUARE_LENGTH + SQUARE_PADDING;
-                var x = (15 * size) * d + 8;
+                var x = (15 * size) * d + v_legendSpacing - 2;
                 var y = (MONTH_LABEL_PADDING - 2);
-                var xLen = (15 * size) * (d + 1) + 9;
+                var xLen = (15 * size) * (d + 1) + v_legendSpacing - 1;
                 var yLen = (MONTH_LABEL_PADDING - 2) + (size * 7) + 1;
                 return "M" + x + "," + y + "H" + xLen + "V" + yLen + "H" + x + "Z";
             }
@@ -325,7 +327,8 @@ function calendarHeatmap() {
         // Draw the hourly chart
         function drawHourlyChart() {
 
-            height = 6 * (SQUARE_LENGTH + SQUARE_PADDING) + 10;
+            v_legendSpacing = 45;
+            height = 10 * (SQUARE_LENGTH + SQUARE_PADDING);
 
             var svg = d3.select(chart.selector())
                 .style('position', 'relative')
@@ -347,7 +350,7 @@ function calendarHeatmap() {
                 .attr('x', function (d, i) {
                     var cellDate = moment.utc(d);
                     var result = (cellDate.diff(firstDateForHour, 'day') * 4 + (cellDate.hour() % 4)) * (SQUARE_LENGTH + SQUARE_PADDING);
-                    return result;
+                    return result + v_legendSpacing;
                 })
                 .attr('y', function (d, i) {
                     var cellDate = moment.utc(d);
@@ -371,7 +374,7 @@ function calendarHeatmap() {
                         .append('div')
                         .attr('class', 'cell-tooltip')
                         .html(tooltipHTMLForDate(d))
-                        .style('left', function () { return Math.floor(i / 6) * SQUARE_LENGTH + 'px'; })
+                        .style('left', function () { return Math.floor(i / 6) * SQUARE_LENGTH + v_legendSpacing + 'px'; })
                         .style('top', function () {
 	                        const height = d3.select('.cell-tooltip').node().getBoundingClientRect().height;
                             return Math.floor(cellDate.hour() / 4) * (SQUARE_LENGTH + SQUARE_PADDING) + DAY_LABEL_PADDING + HEATMAP_PADDING - height + 'px';
@@ -398,15 +401,15 @@ function calendarHeatmap() {
                     .attr('class', 'calendar-heatmap-legend')
                     .attr('width', SQUARE_LENGTH)
                     .attr('height', SQUARE_LENGTH)
-                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing); })
-                    .attr('y', height + SQUARE_PADDING + SQUARE_LENGTH)
+                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + v_legendSpacing; })
+                    .attr('y', height - (SQUARE_PADDING + SQUARE_LENGTH))
                     .attr('fill', function (d) { return d.value; });
 
                 legendGroup.append('text')
                     .attr('class', 'calendar-heatmap-legend-text calendar-heatmap-legend-text-less')
                     .text(function(d) { return (d.key === 'warning' ? locale.Anomaly : (d.key === 'success' ? locale.NoAnomaly : (d.key === 'error' ? locale.Error : (d.key === 'nodata' ? locale.NoData : locale.defaultMsg)))); })
-                    .attr('x', function (d, i) { return (SQUARE_LENGTH + SQUARE_PADDING) + i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing); })
-                    .attr('y', height + 2 * SQUARE_LENGTH)
+                    .attr('x', function (d, i) { return (SQUARE_LENGTH + SQUARE_PADDING) + i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + v_legendSpacing; })
+                    .attr('y', height - 2 * SQUARE_PADDING)
             }
 
             hourRects.exit().remove();
@@ -425,9 +428,9 @@ function calendarHeatmap() {
                         matchIndex = index;
                         return cellDate.isSame(element, 'day');
                     });
-                    return Math.floor(matchIndex / 6) * (SQUARE_LENGTH + SQUARE_PADDING);
+                    return Math.floor(matchIndex / 6) * (SQUARE_LENGTH + SQUARE_PADDING) + v_legendSpacing;
                 })
-                .attr('y', 0);
+                .attr('y', SQUARE_LENGTH - SQUARE_PADDING);
 
             var bars = svg.selectAll(".bars")
                 .data(twoWeeksRange)
@@ -438,7 +441,7 @@ function calendarHeatmap() {
             locale_hour.hours.forEach(function (hour, index) {
                 svg.append('text')
                     .attr('class', 'day-initial')
-                    .attr('transform', 'translate(-46,' + (SQUARE_LENGTH + SQUARE_PADDING) * (index + 1) + ')')
+                    .attr('transform', 'translate(0,' + ((SQUARE_LENGTH + SQUARE_PADDING) * (index + 1) + (SQUARE_LENGTH - SQUARE_PADDING)) + ')')
                     .style('text-anchor', 'left')
                     .attr('dy', '2')
                     .text(hour);
@@ -447,14 +450,19 @@ function calendarHeatmap() {
             function dayPath(d) {
                 var index = moment.utc(d).diff(firstDateForHour, 'day'),
                     size = SQUARE_LENGTH + SQUARE_PADDING;
-                return "M" + (index * 4 * size - 2) + "," + (MONTH_LABEL_PADDING - 2) + "H" + ((index + 1) * 4 * size - 1) + "V" + (MONTH_LABEL_PADDING - 1 + (6 * size)) + "H" + (index * 4 * size - 2) + "Z";
+                    x = (index * 4 * size + v_legendSpacing - 2);
+                    y = (DAY_LABEL_PADDING - 2);
+                    xLen = ((index + 1) * 4 * size + v_legendSpacing - 1);
+                    yLen = (DAY_LABEL_PADDING - 1 + (6 * size));
+                return "M" + x + "," + y + "H" + xLen + "V" + yLen + "H" + x + "Z";
             }
         }
 
         // Draw the daily chart
         function drawDailyChart() {
 
-            height = 7 * (SQUARE_LENGTH + SQUARE_PADDING) + 10;
+            v_legendSpacing = 30;
+            height = 10 * (SQUARE_LENGTH + SQUARE_PADDING);
 
             var svg = d3.select(chart.selector())
                 .style('position', 'relative')
@@ -476,7 +484,7 @@ function calendarHeatmap() {
                 .attr('x', function (d, i) {
                     var cellDate = moment.utc(d);
                     var result = cellDate.week() - firstDate.week() + (firstDate.weeksInYear() * (cellDate.weekYear() - firstDate.weekYear()));
-                    return result * (SQUARE_LENGTH + SQUARE_PADDING);
+                    return result * (SQUARE_LENGTH + SQUARE_PADDING) + v_legendSpacing;
                 })
                 .attr('y', function (d, i) {
                     return MONTH_LABEL_PADDING + formatWeekday(d) * (SQUARE_LENGTH + SQUARE_PADDING);
@@ -498,7 +506,7 @@ function calendarHeatmap() {
                     .append('div')
                     .attr('class', 'cell-tooltip')
                     .html(tooltipHTMLForDate(d))
-                    .style('left', function () { return Math.floor(i / 7) * SQUARE_LENGTH + 'px'; })
+                    .style('left', function () { return Math.floor(i / 7) * SQUARE_LENGTH + v_legendSpacing + 'px'; })
                     .style('top', function () {
 	                    const height = d3.select('.cell-tooltip').node().getBoundingClientRect().height;
                         return formatWeekday(d) * (SQUARE_LENGTH + SQUARE_PADDING) + MONTH_LABEL_PADDING + HEATMAP_PADDING - height + 'px';
@@ -525,18 +533,18 @@ function calendarHeatmap() {
                     .attr('class', 'calendar-heatmap-legend')
                     .attr('width', SQUARE_LENGTH)
                     .attr('height', SQUARE_LENGTH)
-                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing); })
-                    .attr('y', height + SQUARE_PADDING + SQUARE_LENGTH)
+                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + v_legendSpacing; })
+                    .attr('y', height - (SQUARE_PADDING + SQUARE_LENGTH))
                     .attr('fill', function (d) { return d.value; });
 
                 legendGroup.append('text')
                     .attr('class', 'calendar-heatmap-legend-text calendar-heatmap-legend-text-less')
                     .text(function(d) { return (d.key === 'warning' ? locale.Anomaly : (d.key === 'success' ? locale.NoAnomaly : (d.key === 'error' ? locale.Error : (d.key === 'nodata' ? locale.NoData : locale.defaultMsg)))); })
-                    .attr('x', function (d, i) { return (SQUARE_LENGTH + SQUARE_PADDING) + i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing); })
-                    .attr('y', height + 2 * SQUARE_LENGTH)
+                    .attr('x', function (d, i) { return (SQUARE_LENGTH + SQUARE_PADDING) + i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + v_legendSpacing; })
+                    .attr('y', height - 2 * SQUARE_PADDING)
             }
 
-            dayRects.exit().remove();
+            //dayRects.exit().remove();
             var monthLabels = svg.selectAll('.month')
                 .data(monthRange)
                 .enter().append('text')
@@ -556,9 +564,9 @@ function calendarHeatmap() {
                             scale += 2;
                         }
                     }
-                    return scale * (SQUARE_LENGTH + SQUARE_PADDING);
+                    return scale * (SQUARE_LENGTH + SQUARE_PADDING) + v_legendSpacing;
                 })
-                .attr('y', 0);
+                .attr('y', SQUARE_LENGTH - SQUARE_PADDING);
 
             var bars = svg.selectAll(".bars")
                   .data(monthRange)
@@ -569,7 +577,7 @@ function calendarHeatmap() {
             locale.days.forEach(function (day, index) {
                 svg.append('text')
                     .attr('class', 'day-initial')
-                    .attr('transform', 'translate(-30,' + (SQUARE_LENGTH + SQUARE_PADDING) * (index + 1) + ')')
+                    .attr('transform', 'translate(0,' + ((SQUARE_LENGTH + SQUARE_PADDING) * (index + 1) + (SQUARE_LENGTH - SQUARE_PADDING)) + ')')
                     .style('text-anchor', 'left')
                     .attr('dy', '2')
                     .text(day);
@@ -581,9 +589,9 @@ function calendarHeatmap() {
                     end = moment.utc(d).endOf('month'),
                     startOffsetX = start.week() - firstDate.week() + (firstDate.weeksInYear() * (start.weekYear() - firstDate.weekYear())),
                     endOffsetX = end.week() - firstDate.week() + (firstDate.weeksInYear() * (end.weekYear() - firstDate.weekYear())),
-                    startX = startOffsetX * (SQUARE_LENGTH + SQUARE_PADDING) - 2,
+                    startX = startOffsetX * (SQUARE_LENGTH + SQUARE_PADDING) - 2 + v_legendSpacing,
                     startY = MONTH_LABEL_PADDING + (start.isoWeekday() % 7) * (SQUARE_LENGTH + SQUARE_PADDING) - 2,
-                    endX = (endOffsetX + 1) * (SQUARE_LENGTH + SQUARE_PADDING) - 1,
+                    endX = (endOffsetX + 1) * (SQUARE_LENGTH + SQUARE_PADDING) - 1 + v_legendSpacing,
                     endY = MONTH_LABEL_PADDING + ((end.isoWeekday() % 7) + 1) * (SQUARE_LENGTH + SQUARE_PADDING) - 1;
                     size = SQUARE_LENGTH + SQUARE_PADDING;
                 return "M" + startX + "," + startY + "H" + (startX + size) + "V" + (MONTH_LABEL_PADDING - 2) + "H" + endX + "V" + endY + "H" + (endX - size)
@@ -595,7 +603,8 @@ function calendarHeatmap() {
         function drawWeeklyChart() {
 
             SQUARE_PADDING = 4;
-            height = 7 * (SQUARE_LENGTH + SQUARE_PADDING) + 10;
+            v_legendSpacing = 30;
+            height = 10 * (SQUARE_LENGTH + SQUARE_PADDING);
 
             var svg = d3.select(chart.selector())
                 .style('position', 'relative')
@@ -617,7 +626,7 @@ function calendarHeatmap() {
                 .attr('x', function (d, i) {
                     var cellDate = moment.utc(d);
                     var result = cellDate.diff(firstDateForWeek , 'week');
-                    return result * (SQUARE_LENGTH + SQUARE_PADDING);
+                    return result * (SQUARE_LENGTH + SQUARE_PADDING) + v_legendSpacing;
                 })
                 .attr('y', function (d, i) {
                     return MONTH_LABEL_PADDING;
@@ -639,7 +648,7 @@ function calendarHeatmap() {
                         .append('div')
                         .attr('class', 'cell-tooltip')
                         .html(tooltipHTMLForDate(d))
-                        .style('left', function () { return i * (SQUARE_LENGTH + SQUARE_PADDING) + 'px'; })
+                        .style('left', function () { return i * (SQUARE_LENGTH + SQUARE_PADDING) + v_legendSpacing + 'px'; })
                         .style('top', function () {
 	                        const height = d3.select('.cell-tooltip').node().getBoundingClientRect().height;
 	                        return MONTH_LABEL_PADDING + HEATMAP_PADDING - height + 'px';
@@ -666,15 +675,15 @@ function calendarHeatmap() {
                     .attr('class', 'calendar-heatmap-legend')
                     .attr('width', SQUARE_LENGTH)
                     .attr('height', SQUARE_LENGTH)
-                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing); })
-                    .attr('y', height + SQUARE_PADDING + SQUARE_LENGTH)
+                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + v_legendSpacing; })
+                    .attr('y', height - (SQUARE_PADDING + SQUARE_LENGTH))
                     .attr('fill', function (d) { return d.value; });
 
                 legendGroup.append('text')
                     .attr('class', 'calendar-heatmap-legend-text calendar-heatmap-legend-text-less')
                     .text(function(d) { return (d.key === 'warning' ? locale.Anomaly : (d.key === 'success' ? locale.NoAnomaly : (d.key === 'error' ? locale.Error : (d.key === 'nodata' ? locale.NoData : locale.defaultMsg)))); })
-                    .attr('x', function (d, i) { return (SQUARE_LENGTH + SQUARE_PADDING) + i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing); })
-                    .attr('y', height + 2 * SQUARE_LENGTH)
+                    .attr('x', function (d, i) { return (SQUARE_LENGTH + SQUARE_PADDING) + i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + v_legendSpacing; })
+                    .attr('y', height - 2 * SQUARE_PADDING)
             }
 
             weekRects.exit().remove();
@@ -692,9 +701,9 @@ function calendarHeatmap() {
                     if (diff > 0) {
                         scale = Math.floor(diff / 7);
                     }
-                    return scale * (SQUARE_LENGTH + SQUARE_PADDING);
+                    return scale * (SQUARE_LENGTH + SQUARE_PADDING) + v_legendSpacing;
                 })
-                .attr('y', 0);
+                .attr('y', SQUARE_LENGTH - SQUARE_PADDING);
 
             var bars = svg.selectAll(".bars")
                 .data(monthRange)
@@ -706,7 +715,7 @@ function calendarHeatmap() {
                 if (weekStart === 1) { index = (index === 0) ? 6 : index - 1;}
                 svg.append('text')
                     .attr('class', 'day-initial')
-                    .attr('transform', 'translate(-30,' + (SQUARE_LENGTH + SQUARE_PADDING) * (index + 1) + ')')
+                    .attr('transform', 'translate(0,' + ((SQUARE_LENGTH + SQUARE_PADDING) * (index + 1) + (SQUARE_LENGTH - SQUARE_PADDING)) + ')')
                     .style('text-anchor', 'left')
                     .attr('dy', '2')
                     .text(day);
@@ -720,7 +729,11 @@ function calendarHeatmap() {
                 if (diff > 0) {
                     scale = Math.floor(diff / 7);
                 }
-                return "M" + (scale * size - 2) + "," + (MONTH_LABEL_PADDING - 2) + "H" + ((lastIndex + 1) * size - 2) + "V" + (MONTH_LABEL_PADDING + 2 + (7 * size)) + "H" + (scale * size - 2) + "Z";
+                x = (scale * size + v_legendSpacing - 2);
+                y = (MONTH_LABEL_PADDING - 2);
+                xLen = ((lastIndex + 1) * size + v_legendSpacing - 2);
+                yLen = (MONTH_LABEL_PADDING + 2 + (7 * size));
+                return "M" + x + "," + y + "H" + xLen + "V" + yLen + "H" + x + "Z";
             }
         }
 
@@ -728,7 +741,8 @@ function calendarHeatmap() {
         function drawMonthyChart() {
 
             monthRange = d3.utcMonths(moment.utc(yearAgo).subtract(1, 'month') , moment.utc(now).subtract(1, 'month'));
-            height = 4 * (SQUARE_LENGTH + SQUARE_PADDING) + 10;
+            height = 10 * (SQUARE_LENGTH + SQUARE_PADDING);
+            v_legendSpacing = 30;
 
             var svg = d3.select(chart.selector())
                 .style('position', 'relative')
@@ -748,7 +762,7 @@ function calendarHeatmap() {
                 .attr('height', 4 * (SQUARE_LENGTH + SQUARE_PADDING))
                 .attr('fill', function(d) { return colorMap.get(typeForDate(d)); })
                 .attr('x', function (d, i) {
-                    return i * 4 * (SQUARE_LENGTH + SQUARE_PADDING) + i * 3;
+                    return i * 4 * (SQUARE_LENGTH + SQUARE_PADDING) + i * 3 + v_legendSpacing;
                 })
                 .attr('y', function (d, i) {
                     return MONTH_LABEL_PADDING;
@@ -770,7 +784,7 @@ function calendarHeatmap() {
                     .append('div')
                     .attr('class', 'cell-tooltip')
                     .html(tooltipHTMLForDate(d))
-                    .style('left', function () { return (i * 4 * (SQUARE_LENGTH + SQUARE_PADDING) + i * 3) + 'px'; })
+                    .style('left', function () { return (i * 4 * (SQUARE_LENGTH + SQUARE_PADDING) + (i * 3) + v_legendSpacing) + 'px'; })
                     .style('top', function () {
 	                    const height = d3.select('.cell-tooltip').node().getBoundingClientRect().height;
                         return MONTH_LABEL_PADDING + HEATMAP_PADDING - height + 'px';
@@ -797,15 +811,15 @@ function calendarHeatmap() {
                     .attr('class', 'calendar-heatmap-legend')
                     .attr('width', SQUARE_LENGTH)
                     .attr('height', SQUARE_LENGTH)
-                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing); })
-                    .attr('y', height + SQUARE_PADDING + SQUARE_LENGTH)
+                    .attr('x', function (d, i) { return i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + v_legendSpacing; })
+                    .attr('y', height - (SQUARE_PADDING + SQUARE_LENGTH))
                     .attr('fill', function (d) { return d.value; });
 
                 legendGroup.append('text')
                   .attr('class', 'calendar-heatmap-legend-text calendar-heatmap-legend-text-less')
                   .text(function(d) { return (d.key === 'warning' ? locale.Anomaly : (d.key === 'success' ? locale.NoAnomaly : (d.key === 'error' ? locale.Error : (d.key === 'nodata' ? locale.NoData : locale.defaultMsg)))); })
-                  .attr('x', function (d, i) { return (SQUARE_LENGTH + SQUARE_PADDING) + i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing); })
-                  .attr('y', height + 2 * SQUARE_LENGTH)
+                  .attr('x', function (d, i) { return (SQUARE_LENGTH + SQUARE_PADDING) + i * ((SQUARE_LENGTH + SQUARE_PADDING) * legendSpacing) + v_legendSpacing; })
+                  .attr('y', height - 2 * SQUARE_PADDING)
             }
 
             var bars = svg.selectAll(".bars")
@@ -825,14 +839,18 @@ function calendarHeatmap() {
                     return locale.months[utcDate.month()] + "'" + String(utcDate.format('YYYY')).substring(2,4);
                 })
                 .attr('x', function (d, i) {
-                    return i * 4 * (SQUARE_LENGTH + SQUARE_PADDING) + i * 3;
+                    return i * 4 * (SQUARE_LENGTH + SQUARE_PADDING) + i * 3 + v_legendSpacing;
                 })
-                .attr('y', 0);
+                .attr('y', SQUARE_LENGTH - SQUARE_PADDING);
 
             function monthPath(d) {
                 var index = moment.utc(d).diff(monthRange[0], 'month'),
                     size = 4 * (SQUARE_LENGTH + SQUARE_PADDING);
-                return "M" + (index * (size + 3) - 3) + "," + (MONTH_LABEL_PADDING - 2) + "H" + ((index + 1) * (size + 3) - 3) + "V" + (MONTH_LABEL_PADDING + 2 + size) + "H" + (index * (size + 3) - 3) + "Z";
+                    x = (index * (size + 3) +v_legendSpacing - 3);
+                    y = (MONTH_LABEL_PADDING - 2);
+                    xLen = ((index + 1) * (size + 3) + v_legendSpacing - 3);
+                    yLen = (MONTH_LABEL_PADDING + 2 + size);
+                return "M" + x + "," + y + "H" + xLen + "V" + yLen + "H" + x + "Z";
             }
         }
     }

--- a/src/test/java/com/yahoo/sherlock/enums/TriggersTest.java
+++ b/src/test/java/com/yahoo/sherlock/enums/TriggersTest.java
@@ -18,8 +18,8 @@ public class TriggersTest {
 
     @Test
     public void testTriggersToString() {
-        Triggers[] triggers = {Triggers.MINUTE, Triggers.DAY, Triggers.HOUR, Triggers.MONTH, Triggers.WEEK};
-        String[] expected = {"minute", "day", "hour", "month", "week"};
+        Triggers[] triggers = {Triggers.INSTANT, Triggers.MINUTE, Triggers.DAY, Triggers.HOUR, Triggers.MONTH, Triggers.WEEK};
+        String[] expected = {"instant", "minute", "day", "hour", "month", "week"};
         for (int i = 0; i < triggers.length; i++) {
             assertEquals(triggers[i].toString(), expected[i]);
         }
@@ -27,7 +27,7 @@ public class TriggersTest {
 
     @Test
     public void testGetAllValues() {
-        assertEquals(Triggers.getAllValues().size(), 5);
+        assertEquals(Triggers.getAllValues().size(), 6);
     }
 
     /**
@@ -41,6 +41,7 @@ public class TriggersTest {
 
     @Test
     public void testGetMinutes() {
+        assertEquals(Triggers.INSTANT.getMinutes(), 0);
         assertEquals(Triggers.MINUTE.getMinutes(), 1);
         assertEquals(Triggers.HOUR.getMinutes(), 60);
         assertEquals(Triggers.DAY.getMinutes(), 1440);
@@ -50,6 +51,7 @@ public class TriggersTest {
 
     @Test
     public void testGetValue() {
+        assertEquals(Triggers.getValue("instant"), Triggers.INSTANT);
         assertEquals(Triggers.getValue("minute"), Triggers.MINUTE);
         assertEquals(Triggers.getValue("hour"), Triggers.HOUR);
         assertEquals(Triggers.getValue("day"), Triggers.DAY);

--- a/src/test/java/com/yahoo/sherlock/exception/ExceptionTest.java
+++ b/src/test/java/com/yahoo/sherlock/exception/ExceptionTest.java
@@ -64,6 +64,20 @@ public class ExceptionTest {
     }
 
     @Test
+    public void testEmailNotFoundExceptionConstructors() {
+        EmailNotFoundException e = new EmailNotFoundException();
+        assertNull(e.getMessage());
+        assertNull(e.getCause());
+        e = new EmailNotFoundException("some_message");
+        assertEquals(e.getMessage(), "some_message");
+        assertNull(e.getCause());
+        Exception cause = new RuntimeException("fake_message");
+        e = new EmailNotFoundException("some_message", cause);
+        assertEquals(e.getMessage(), "some_message");
+        assertEquals(e.getCause().getMessage(), "fake_message");
+    }
+
+    @Test
     public void testSherlockExceptionConstructors() {
         SherlockException e = new SherlockException();
         assertNull(e.getMessage());

--- a/src/test/java/com/yahoo/sherlock/model/AnomalyReportTest.java
+++ b/src/test/java/com/yahoo/sherlock/model/AnomalyReportTest.java
@@ -40,14 +40,14 @@ public class AnomalyReportTest {
         rep.setAnomalyTimestamps(timestampStr);
         String result = rep.getFormattedAnomalyTimestamps();
         String expected = String.format(
-            "%s%n%s%n%s to %s%n%s%n%s to %s",
-            formatHrs(337),
-            formatHrs(554),
-            formatHrs(557),
-            formatHrs(560),
-            formatHrs(3000),
-            formatHrs(3200),
-            formatHrs(3300)
+                "%s%n%s%n%s to %s%n%s%n%s to %s",
+                formatHrs(337),
+                formatHrs(554),
+                formatHrs(557),
+                formatHrs(560),
+                formatHrs(3000),
+                formatHrs(3200),
+                formatHrs(3300)
         );
         assertEquals(result, expected);
     }
@@ -60,11 +60,11 @@ public class AnomalyReportTest {
         List<int[]> result = rep.getAnomalyTimestampsHours();
         int[][] resArr = result.toArray(new int[0][]);
         int[][] expected = {
-            {337, 0},
-            {554, 0},
-            {557, 560},
-            {3000, 0},
-            {3200, 3300}
+                {337, 0},
+                {554, 0},
+                {557, 560},
+                {3000, 0},
+                {3200, 3300}
         };
         String expectedDeviationString = "23,-40,45,-1,90";
         for (int i = 0; i < expected.length; i++) {
@@ -78,11 +78,11 @@ public class AnomalyReportTest {
     public void testSetAnomalyTimestampsFromIntervalsCorrectlySetsValues() {
         String expected = "337@0,554@-100,557:560@0,3000@-100,3200:3300@3";
         int[][] source = {
-            {337, 337},
-            {554, 0},
-            {557, 560},
-            {3000, 0},
-            {3200, 3300}
+                {337, 337},
+                {554, 0},
+                {557, 560},
+                {3000, 0},
+                {3200, 3300}
         };
         Anomaly.IntervalSequence seq = new Anomaly.IntervalSequence();
         for (int[] pair : source) {
@@ -137,18 +137,18 @@ public class AnomalyReportTest {
     @Test
     public void testParameterConstructor() {
         AnomalyReport rep = new AnomalyReport(
-            "uniqueId",
-            "metricName",
-            "groupByFilters",
-            "anomalyTimestamps",
-            "queryUrl",
-            12345,
-            1,
-            "jobFrequency",
-            "status",
-            "model",
-            "3.0",
-            "xyz"
+                "uniqueId",
+                "metricName",
+                "groupByFilters",
+                "anomalyTimestamps",
+                "queryUrl",
+                12345,
+                1,
+                "jobFrequency",
+                "status",
+                "model",
+                "3.0",
+                "xyz"
         );
         assertEquals(rep.getUniqueId(), "uniqueId");
         assertEquals(rep.getMetricName(), "metricName");

--- a/src/test/java/com/yahoo/sherlock/model/EmailMetaDataTest.java
+++ b/src/test/java/com/yahoo/sherlock/model/EmailMetaDataTest.java
@@ -1,0 +1,63 @@
+package com.yahoo.sherlock.model;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * EmailMetadata test class.
+ */
+public class EmailMetaDataTest {
+
+    private EmailMetaData emailMetaData;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        emailMetaData = new EmailMetaData("email");
+    }
+
+    @Test
+    public void testGetEmailId() throws Exception {
+        assertEquals(emailMetaData.getEmailId(), "email");
+    }
+
+    @Test
+    public void testGetSendOutHour() throws Exception {
+        assertEquals(emailMetaData.getSendOutHour(), "12");
+    }
+
+    @Test
+    public void testGetSendOutMinute() throws Exception {
+        assertEquals(emailMetaData.getSendOutMinute(), "00");
+    }
+
+    @Test
+    public void testGetRepeatInterval() throws Exception {
+        assertEquals(emailMetaData.getRepeatInterval(), "instant");
+    }
+
+    @Test
+    public void testSetEmailId() throws Exception {
+        emailMetaData.setEmailId("emailll");
+        assertEquals(emailMetaData.getEmailId(), "emailll");
+    }
+
+    @Test
+    public void testSetSendOutHour() throws Exception {
+        emailMetaData.setSendOutHour("23");
+        assertEquals(emailMetaData.getSendOutHour(), "23");
+    }
+
+    @Test
+    public void testSetSendOutMinute() throws Exception {
+        emailMetaData.setSendOutMinute("54");
+        assertEquals(emailMetaData.getSendOutMinute(), "54");
+    }
+
+    @Test
+    public void testSetRepeatInterval() throws Exception {
+        emailMetaData.setRepeatInterval("day");
+        assertEquals(emailMetaData.getRepeatInterval(), "day");
+    }
+}

--- a/src/test/java/com/yahoo/sherlock/scheduler/ExecutionTaskTest.java
+++ b/src/test/java/com/yahoo/sherlock/scheduler/ExecutionTaskTest.java
@@ -9,21 +9,38 @@ import com.yahoo.sherlock.enums.Granularity;
 import com.yahoo.sherlock.enums.JobStatus;
 import com.yahoo.sherlock.exception.SchedulerException;
 import com.yahoo.sherlock.model.JobMetadata;
+import com.yahoo.sherlock.service.EmailService;
 import com.yahoo.sherlock.store.JobMetadataAccessor;
 import com.yahoo.sherlock.store.JobScheduler;
+import com.yahoo.sherlock.utils.TimeUtils;
+
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.ZonedDateTime;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 public class ExecutionTaskTest {
+
+    private static void inject(ExecutionTask et, String n, Object v) {
+        try {
+            Field f = ExecutionTask.class.getDeclaredField(n);
+            f.setAccessible(true);
+            f.set(et, v);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            fail(e.toString());
+        }
+    }
 
     @Test
     public void testExecutionTaskConsumeAndExecute() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException,
@@ -32,7 +49,9 @@ public class ExecutionTaskTest {
         JobScheduler js = Mockito.mock(JobScheduler.class);
         SchedulerService ss = Mockito.mock(SchedulerService.class);
         JobMetadataAccessor jma = Mockito.mock(JobMetadataAccessor.class);
+        EmailService ems = Mockito.mock(EmailService.class);
         ExecutionTask et = new ExecutionTask(jes, ss, js, jma);
+        inject(et, "emailService", ems);
         JobMetadata jm = new JobMetadata();
         Integer[] idPtr = new Integer[] {5};
         jm.setJobId(idPtr[0]);
@@ -53,6 +72,7 @@ public class ExecutionTaskTest {
                 }
             }
         });
+        Mockito.doNothing().when(ems).sendConsolidatedEmail(any(), any());
         Method m = et.getClass().getDeclaredMethod("consumeAndExecuteTasks", long.class);
         m.setAccessible(true);
         m.invoke(et, 12345);
@@ -75,6 +95,37 @@ public class ExecutionTaskTest {
         Mockito.verify(ss, Mockito.times(0)).rescheduleJob(any(JobMetadata.class));
         Mockito.verify(js, Mockito.times(1)).popQueue(anyLong());
         Mockito.verify(jma, Mockito.times(0)).putJobMetadata(any(JobMetadata.class));
+    }
+
+    @Test
+    public void testRunEmailSender() throws IOException {
+        JobExecutionService jes = Mockito.mock(JobExecutionService.class);
+        JobScheduler js = Mockito.mock(JobScheduler.class);
+        SchedulerService ss = Mockito.mock(SchedulerService.class);
+        JobMetadataAccessor jma = Mockito.mock(JobMetadataAccessor.class);
+        EmailService ems = Mockito.mock(EmailService.class);
+        ExecutionTask et = new ExecutionTask(jes, ss, js, jma);
+        inject(et, "emailService", ems);
+        Mockito.doNothing().when(ems).sendConsolidatedEmail(any(), any());
+        long time = 33 * 24 * 60L + 13 * 60L + 12L;
+        ZonedDateTime zonedTime = TimeUtils.zonedDateTimeFromMinutes(time);
+        assertEquals(zonedTime.getDayOfMonth(), 3);
+        assertEquals(zonedTime.getDayOfWeek().getValue(), 2);
+        // test without first day of month/first day of week(monday)
+        et.runEmailSender(time);
+        Mockito.verify(ems, Mockito.times(2)).sendConsolidatedEmail(any(), any());
+        // test with first day of month
+        time = time - 2 * 24 * 60L;
+        zonedTime = TimeUtils.zonedDateTimeFromMinutes(time);
+        assertEquals(zonedTime.getDayOfMonth(), 1);
+        et.runEmailSender(time);
+        Mockito.verify(ems, Mockito.times(5)).sendConsolidatedEmail(any(), any());
+        // test with first day of week
+        time = time + 1 * 24 * 60L;
+        zonedTime = TimeUtils.zonedDateTimeFromMinutes(time);
+        assertEquals(zonedTime.getDayOfWeek().getValue(), 1);
+        et.runEmailSender(time);
+        Mockito.verify(ems, Mockito.times(8)).sendConsolidatedEmail(any(), any());
     }
 
 }

--- a/src/test/java/com/yahoo/sherlock/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/com/yahoo/sherlock/scheduler/SchedulerServiceTest.java
@@ -146,6 +146,24 @@ public class SchedulerServiceTest {
     }
 
     @Test
+    public void testRemoveAllFromQueue() throws SchedulerException, IOException {
+        init();
+        doCallRealMethod().when(ss).removeAllJobsFromQueue();
+        ss.removeAllJobsFromQueue();
+        Mockito.verify(js, Mockito.times(1)).removeAllQueue();
+        IOException ioex = new IOException("error");
+        Mockito.doThrow(ioex).when(js).removeAllQueue();
+        try {
+            ss.removeAllJobsFromQueue();
+        } catch (SchedulerException e) {
+            Assert.assertEquals(e.getMessage(), "error");
+            Assert.assertEquals(e.getCause(), ioex);
+            return;
+        }
+        Assert.fail();
+    }
+
+    @Test
     public void testJobScheduleTimeAndRescheduleTime() {
         init();
         int hoursOfLag = 36;

--- a/src/test/java/com/yahoo/sherlock/service/DetectorServiceTest.java
+++ b/src/test/java/com/yahoo/sherlock/service/DetectorServiceTest.java
@@ -174,9 +174,9 @@ public class DetectorServiceTest {
     public void testRunDetection() throws SherlockException {
         initMocks();
         when(ds.runDetection(any(), anyDouble(), any(EgadsConfig.class), anyInt(), anyString(), any(Granularity.class), anyInt()))
-            .thenReturn(Collections.singletonList(new Anomaly()));
+                .thenReturn(Collections.singletonList(new Anomaly()));
         when(ds.runDetection(any(JsonArray.class), any(), anyDouble(), any(EgadsConfig.class), anyString(), anyInt()))
-            .thenCallRealMethod();
+                .thenCallRealMethod();
         Query query = mock(Query.class);
         when(query.getRunTime()).thenReturn(100000);
         when(query.getGranularity()).thenReturn(Granularity.HOUR);
@@ -188,7 +188,7 @@ public class DetectorServiceTest {
     public void testRunDetectionNoConfig() throws Exception {
         initMocks();
         when(ds.runDetection(any(), anyDouble(), any(EgadsConfig.class), anyInt(), anyString(), any(Granularity.class), anyInt()))
-            .thenReturn(Collections.singletonList(new Anomaly()));
+                .thenReturn(Collections.singletonList(new Anomaly()));
         when(ds.runDetection(any(), anyDouble(), any(), anyInt(), anyString(), any(Granularity.class), anyInt())).thenCallRealMethod();
         assertEquals(ds.runDetection(Collections.emptyList(), 0.0, null, 1234, null, null, 1).size(), 1);
     }
@@ -206,7 +206,7 @@ public class DetectorServiceTest {
         when(egads.getP()).thenReturn(p);
         when(egads.runEGADS(any(), anyDouble())).thenReturn(anomalies);
         when(ds.runDetection(any(), anyDouble(), any(EgadsConfig.class), anyInt(), anyString(), any(Granularity.class), anyInt()))
-            .thenCallRealMethod();
+                .thenCallRealMethod();
         List<Anomaly> result = ds.runDetection(tslist, 3.0, null, 123, "day", Granularity.DAY, 1);
         assertEquals(result.size(), 3);
         result = ds.runDetection(tslist, 3.0, mock(EgadsConfig.class), 123, "day", Granularity.DAY, 1);
@@ -222,7 +222,7 @@ public class DetectorServiceTest {
         initMocks();
         when(egads.detectAnomaliesResult(any())).thenReturn(res);
         List<TimeSeries> tslist = Lists.newArrayList(
-            new TimeSeries(), new TimeSeries(), new TimeSeries(), new TimeSeries(), new TimeSeries()
+                new TimeSeries(), new TimeSeries(), new TimeSeries(), new TimeSeries(), new TimeSeries()
         );
         when(ps.parseTimeSeries(any(), any())).thenReturn(tslist);
         when(ds.detectWithResults(any(), any(), any(), any(), any())).thenCallRealMethod();

--- a/src/test/java/com/yahoo/sherlock/service/EgadsServiceTest.java
+++ b/src/test/java/com/yahoo/sherlock/service/EgadsServiceTest.java
@@ -138,7 +138,7 @@ public class EgadsServiceTest {
         ProcessableObject po = mock(ProcessableObject.class);
         when(egads.getEgadsProcessableObject(any())).thenReturn(po);
         List<Anomaly> result = Lists.newArrayList(
-            new Anomaly(), new Anomaly(), new Anomaly()
+                new Anomaly(), new Anomaly(), new Anomaly()
         );
         when(po.result()).thenReturn(result);
         when(egads.detectAnomaliesResult(any())).thenCallRealMethod();

--- a/src/test/java/com/yahoo/sherlock/service/EmailServiceTest.java
+++ b/src/test/java/com/yahoo/sherlock/service/EmailServiceTest.java
@@ -8,26 +8,49 @@ package com.yahoo.sherlock.service;
 
 import com.beust.jcommander.internal.Lists;
 import com.yahoo.sherlock.model.AnomalyReport;
+import com.yahoo.sherlock.model.EmailMetaData;
+import com.yahoo.sherlock.model.JobMetadata;
+import com.yahoo.sherlock.settings.CLISettings;
 import com.yahoo.sherlock.settings.Constants;
+import com.yahoo.sherlock.store.AnomalyReportAccessor;
 import com.yahoo.sherlock.store.DBTestHelper;
+import com.yahoo.sherlock.store.EmailMetadataAccessor;
+import com.yahoo.sherlock.utils.TimeUtils;
 
+import org.mockito.Mockito;
 import org.simplejavamail.email.Email;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
 
 /**
  * Test for email service.
  */
 public class EmailServiceTest {
 
+    private AnomalyReportAccessor ara;
+    private EmailMetadataAccessor ema;
     private static boolean status = true;
     private static EmailService emailService;
-
+    private List<String> emails = Arrays.asList("owner@xyzmail.com");
     private static class MockEmailService extends EmailService {
         @Override
         protected boolean sendFormattedEmail(Email emailHandle) {
@@ -35,32 +58,46 @@ public class EmailServiceTest {
         }
 
         @Override
-        public Email createEmailHandle(String owner, String ownerEmailId) {
+        public Email createEmailHandle(String owner, List<String> ownerEmailIds) {
             return new Email();
+        }
+    }
+
+    private static void inject(EmailService ems, String n, Object v) {
+        try {
+            Field f = EmailService.class.getDeclaredField(n);
+            f.setAccessible(true);
+            f.set(ems, v);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            fail(e.toString());
         }
     }
 
     @BeforeMethod
     public void setUp() throws Exception {
         emailService = new MockEmailService();
+        ara = mock(AnomalyReportAccessor.class);
+        ema = mock(EmailMetadataAccessor.class);
+        inject(emailService, "anomalyReportAccessor", ara);
+        inject(emailService, "emailMetadataAccessor", ema);
     }
 
     @Test
     public void testSendEmail() throws Exception {
         AnomalyReport anomalyReport = DBTestHelper.getNewReport();
         anomalyReport.setStatus(Constants.WARNING);
-        Assert.assertTrue(emailService.sendEmail("owner", "owner@xyzmail.com", Collections.singletonList(anomalyReport)));
+        Assert.assertTrue(emailService.sendEmail("owner", emails, Collections.singletonList(anomalyReport)));
         anomalyReport.setStatus(Constants.ERROR);
-        Assert.assertTrue(emailService.sendEmail("owner", "owner@xyzmail.com", Collections.singletonList(anomalyReport)));
+        Assert.assertTrue(emailService.sendEmail("owner", emails, Collections.singletonList(anomalyReport)));
         anomalyReport.setStatus(Constants.NODATA);
-        Assert.assertTrue(emailService.sendEmail("owner", "owner@xyzmail.com", Collections.singletonList(anomalyReport)));
+        Assert.assertTrue(emailService.sendEmail("owner", emails, Collections.singletonList(anomalyReport)));
         anomalyReport.setStatus(Constants.WARNING);
         status = false;
-        Assert.assertFalse(emailService.sendEmail("owner", "owner@xyzmail.com", Collections.singletonList(anomalyReport)));
+        Assert.assertFalse(emailService.sendEmail("owner", emails, Collections.singletonList(anomalyReport)));
     }
     @Test
     public void testException() throws Exception {
-        Assert.assertFalse(emailService.sendEmail("owner", "owner@xyzmail.com", null));
+        Assert.assertFalse(emailService.sendEmail("owner", emails, null));
     }
 
     @Test
@@ -72,7 +109,7 @@ public class EmailServiceTest {
     @Test
     public void testValidateEmailDomain() {
         List<String> validDomains = Lists.newArrayList("yahoo", "hotmail");
-        String[] valid = {"person1@yahoo.com", "person2@yahoo.ca", "person9.lastname1@edu.hotmail.com"};
+        String[] valid = {"person1@yahoo.com", "person2@yahoo.cal", "person9.lastname1@hotmail.com"};
         String[] invalid = {"notanemail", "incomplete@mail", "tumblr.com", "johnny17@tumblr.com"};
         EmailService es = new EmailService();
         for (String s : valid) {
@@ -83,4 +120,64 @@ public class EmailServiceTest {
         }
     }
 
+    @Test
+    public void testSendEmailOtherMethod() {
+        JobMetadata jobMetadata = DBTestHelper.getNewJob();
+        AnomalyReport anomalyReport = DBTestHelper.getNewReport();
+        CLISettings.ENABLE_EMAIL = true;
+        EmailService emailService = mock(EmailService.class);
+        doCallRealMethod().when(emailService).processEmailReports(any(JobMetadata.class), anyList(), anyListOf(AnomalyReport.class));
+        when(emailService.sendEmail(anyString(), anyList(), anyListOf(AnomalyReport.class))).thenReturn(true);
+        // test for error report send
+        anomalyReport.setStatus(Constants.ERROR);
+        emailService.processEmailReports(jobMetadata, emails, Arrays.asList(anomalyReport));
+        // test for error report not send
+        when(emailService.sendEmail(anyString(), anyList(), anyListOf(AnomalyReport.class))).thenReturn(false);
+        emailService.processEmailReports(jobMetadata, emails, Arrays.asList(anomalyReport));
+        // test for nodata report not send
+        anomalyReport.setStatus(Constants.NODATA);
+        emailService.processEmailReports(jobMetadata, emails, Arrays.asList(anomalyReport));
+        // test anomaly report send out
+        AnomalyReport anomalyReport1 = DBTestHelper.getNewReport();
+        anomalyReport.setStatus(Constants.WARNING);
+        anomalyReport1.setStatus(Constants.NODATA);
+        emailService.processEmailReports(jobMetadata, emails, Arrays.asList(anomalyReport, anomalyReport1));
+    }
+
+    private EmailMetaData getEmailMetadata(String email) {
+        return new EmailMetaData(email);
+    }
+
+    @Test
+    public void testSendConsolidatedEmail() throws IOException {
+        EmailMetaData e1 = getEmailMetadata("abc@email.com");
+        EmailMetaData e2 = getEmailMetadata("xyz@email.com");
+        e2.setSendOutMinute("23");
+        AnomalyReport ar = DBTestHelper.getNewReport();
+        ar.setStatus(Constants.WARNING);
+        // test for hourly trigger
+        long time = 33 * 24 * 60L + 13 * 60L + 23;
+        ZonedDateTime zonedTime = TimeUtils.zonedDateTimeFromMinutes(time);
+        when(ema.getAllEmailMetadataByTrigger(anyString())).thenReturn(Arrays.asList(e1, e2));
+        when(ara.getAnomalyReportsForEmailId(anyString())).thenReturn(Arrays.asList(ar));
+        emailService.sendConsolidatedEmail(zonedTime, "hour");
+        Mockito.verify(ara, Mockito.times(1)).getAnomalyReportsForEmailId(e2.getEmailId());
+        // test for daily/weekly/monthly trigger
+        e2.setSendOutHour("13");
+        emailService.sendConsolidatedEmail(zonedTime, "day");
+        Mockito.verify(ara, Mockito.times(2)).getAnomalyReportsForEmailId(e2.getEmailId());
+    }
+
+    @Test
+    public void testCreateEmailHandle() {
+        List<String> emails = new ArrayList<>();
+        emails.add("myemail@gmail.com");
+        emails.add("email@yahoo.com");
+        EmailService emailService = new EmailService();
+        CLISettings.FROM_MAIL = "bla@bla.com";
+        CLISettings.REPLY_TO = "xyz@xyz.com";
+        Email email = emailService.createEmailHandle("aa", emails);
+        CLISettings.FROM_MAIL = "bla@bla.com";
+        Assert.assertEquals(email.getRecipients().size() , 2);
+    }
 }

--- a/src/test/java/com/yahoo/sherlock/store/redis/LettuceEmailMetadataAccessorTest.java
+++ b/src/test/java/com/yahoo/sherlock/store/redis/LettuceEmailMetadataAccessorTest.java
@@ -1,0 +1,157 @@
+package com.yahoo.sherlock.store.redis;
+
+import com.google.common.collect.Sets;
+import com.yahoo.sherlock.enums.Triggers;
+import com.yahoo.sherlock.model.EmailMetaData;
+import com.yahoo.sherlock.store.core.AsyncCommands;
+import com.yahoo.sherlock.store.core.RedisConnection;
+import com.yahoo.sherlock.store.core.SyncCommands;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.yahoo.sherlock.TestUtilities.inject;
+import static com.yahoo.sherlock.store.redis.AbstractLettuceAccessorTest.fakeFuture;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for LettuceEmailMetadataAccessor.
+ */
+public class LettuceEmailMetadataAccessorTest {
+
+    private LettuceEmailMetadataAccessor ema;
+    private AsyncCommands<String> async;
+    private SyncCommands<String> sync;
+    private EmailMetaData emailMetaData;
+
+    private void mocks() {
+        ema = mock(LettuceEmailMetadataAccessor.class);
+        inject(ema, LettuceEmailMetadataAccessor.class, "emailIdIndex", "emailIdIndex");
+        inject(ema, LettuceEmailMetadataAccessor.class, "emailTriggerIndex", "emailTriggerIndex");
+        inject(ema, LettuceEmailMetadataAccessor.class, "emailJobIndex", "emailJobIndex");
+        inject(ema, AbstractLettuceAccessor.class, "keyName", "key");
+        inject(ema, AbstractLettuceAccessor.class, "mapper", new HashMapper());
+        RedisConnection<String> conn = (RedisConnection<String>) mock(RedisConnection.class);
+        RedisConnection<byte[]> bin = (RedisConnection<byte[]>) mock(RedisConnection.class);
+        async = (AsyncCommands<String>) mock(AsyncCommands.class);
+        sync = (SyncCommands<String>) mock(SyncCommands.class);
+        AsyncCommands<byte[]> binAsync = (AsyncCommands<byte[]>) mock(AsyncCommands.class);
+        when(ema.connect()).thenReturn(conn);
+        when(ema.binary()).thenReturn(bin);
+        when(conn.sync()).thenReturn(sync);
+        when(conn.async()).thenReturn(async);
+        when(bin.async()).thenReturn(binAsync);
+        when(ema.key(anyVararg())).thenCallRealMethod();
+        when(ema.unmap(any(), any())).thenCallRealMethod();
+        when(ema.map(any())).thenCallRealMethod();
+    }
+
+    private static Map<String, String> map(EmailMetaData emailMetaData) {
+        return new HashMapper().map(emailMetaData);
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        emailMetaData = new EmailMetaData();
+        emailMetaData.setEmailId("my@email.com");
+        emailMetaData.setSendOutHour("14");
+        emailMetaData.setSendOutMinute("19");
+        emailMetaData.setRepeatInterval(Triggers.INSTANT.toString());
+    }
+
+    @Test
+    public void testPutEmailMetadata() throws Exception {
+        mocks();
+        doCallRealMethod().when(ema).putEmailMetadata(any(EmailMetaData.class));
+        ema.putEmailMetadata(emailMetaData);
+        verify(async).hmset(anyString(), anyMap());
+        verify(async, times(2)).sadd(anyString(), anyVararg());
+        emailMetaData.setRepeatInterval(Triggers.DAY.toString());
+        ema.putEmailMetadata(emailMetaData);
+        verify(async, times(2)).hmset(anyString(), anyMap());
+        verify(async, times(4)).sadd(anyString(), anyVararg());
+    }
+
+    @Test
+    public void testPutEmailMetadataIfNotExist() throws Exception {
+        mocks();
+        doCallRealMethod().when(ema).putEmailMetadataIfNotExist(anyString(), anyString());
+        // if email is present
+        when(async.sadd("emailIdIndex:Emails", emailMetaData.getEmailId())).thenReturn(fakeFuture(Long.valueOf("0")));
+        ema.putEmailMetadataIfNotExist(emailMetaData.getEmailId(), "1");
+        verify(ema, times(0)).putEmailMetadata(any(EmailMetaData.class));
+        verify(async, times(1)).sadd("emailIdIndex:Emails", emailMetaData.getEmailId());
+        verify(async, times(1)).sadd("emailJobIndex:" + emailMetaData.getEmailId(), "1");
+        // if email is not present
+        when(async.sadd("emailIdIndex:Emails", emailMetaData.getEmailId())).thenReturn(fakeFuture(Long.valueOf("1")));
+        ema.putEmailMetadataIfNotExist(emailMetaData.getEmailId(), "2");
+        verify(ema, times(1)).putEmailMetadata(any(EmailMetaData.class));
+        verify(async, times(4)).sadd(anyString(), anyString());
+    }
+
+    @Test
+    public void testGetAllEmailMetadata() throws Exception {
+        mocks();
+        doCallRealMethod().when(ema).getAllEmailMetadata();
+        Set<String> emails = Sets.newHashSet("my@email.com", "1@email.com");
+        when(async.smembers("emailIdIndex:Emails")).thenReturn(fakeFuture(emails));
+        when(async.hgetall(anyString())).thenReturn(fakeFuture(map(emailMetaData)));
+        assertEquals(2, ema.getAllEmailMetadata().size());
+    }
+
+    @Test
+    public void testGetEmailMetadata() throws Exception {
+        mocks();
+        doCallRealMethod().when(ema).getEmailMetadata(anyString());
+        when(async.hgetall("key:" + emailMetaData.getEmailId())).thenReturn(fakeFuture(map(emailMetaData)));
+        EmailMetaData edata = ema.getEmailMetadata(emailMetaData.getEmailId());
+        assertEquals(emailMetaData.getEmailId(), edata.getEmailId());
+        assertEquals(emailMetaData, edata);
+    }
+
+    @Test
+    public void testCheckEmailsInInstantIndex() throws Exception {
+        mocks();
+        doCallRealMethod().when(ema).checkEmailsInInstantIndex(anyList());
+        Set<String> emails = Sets.newHashSet("my@email.com", "1@email.com");
+        when(async.smembers("emailTriggerIndex:instant")).thenReturn(fakeFuture(emails));
+        List<String> remainEmail = ema.checkEmailsInInstantIndex(Arrays.asList("my@email.com"));
+        assertEquals(Arrays.asList("my@email.com"), remainEmail);
+    }
+
+    @Test
+    public void testRemoveFromTriggerIndex() throws Exception {
+        mocks();
+        doCallRealMethod().when(ema).removeFromTriggerIndex(anyString(), anyString());
+        Long l = 0L;
+        when(async.srem("emailTriggerIndex:day", "my@email.com")).thenReturn(fakeFuture(l));
+        ema.removeFromTriggerIndex("my@email.com", "day");
+        verify(async, times(1)).srem("emailTriggerIndex:day", "my@email.com");
+    }
+
+    @Test
+    public void testGetAllEmailMetadataByTrigger() throws IOException {
+        mocks();
+        doCallRealMethod().when(ema).getAllEmailMetadataByTrigger(anyString());
+        Set<String> emails = Sets.newHashSet("my@email.com", "1@email.com");
+        when(async.smembers("emailTriggerIndex:hour")).thenReturn(fakeFuture(emails));
+        when(async.hgetall(anyString())).thenReturn(fakeFuture(map(emailMetaData)));
+        assertEquals(2, ema.getAllEmailMetadataByTrigger("hour").size());
+    }
+}

--- a/src/test/java/com/yahoo/sherlock/store/redis/LettuceJsonDumperTest.java
+++ b/src/test/java/com/yahoo/sherlock/store/redis/LettuceJsonDumperTest.java
@@ -1,0 +1,67 @@
+package com.yahoo.sherlock.store.redis;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import com.yahoo.sherlock.settings.DatabaseConstants;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.yahoo.sherlock.TestUtilities.inject;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test class for json dump.
+ */
+public class LettuceJsonDumperTest {
+
+    private LettuceJsonDumper lettuceJsonDumper;
+    private Gson gson = new Gson();
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        lettuceJsonDumper = mock(LettuceJsonDumper.class);
+        inject(lettuceJsonDumper, LettuceJsonDumper.class, "gson", gson);
+    }
+
+    @Test
+    public void testWriteRawData() throws Exception {
+        doCallRealMethod().when(lettuceJsonDumper).writeRawData(any());
+        doNothing().when(lettuceJsonDumper).writeAnomalyTimestampsToRedis(anyMap());
+        doNothing().when(lettuceJsonDumper).writeObjectsToRedis(anyMap());
+        doNothing().when(lettuceJsonDumper).writeIndexesToRedis(anyMap());
+        doNothing().when(lettuceJsonDumper).writeIdsToRedis(anyMap());
+        String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/redis_json_dump.json")));
+        JsonObject jsonObject = new Gson().fromJson(jsonString, JsonObject.class);
+        lettuceJsonDumper.writeRawData(jsonObject);
+        verify(lettuceJsonDumper, times(1)).writeAnomalyTimestampsToRedis(anyMap());
+        verify(lettuceJsonDumper, times(1)).writeIndexesToRedis(anyMap());
+        verify(lettuceJsonDumper, times(1)).writeObjectsToRedis(anyMap());
+        verify(lettuceJsonDumper, times(1)).writeIdsToRedis(anyMap());
+        Set<String> tempSet = new HashSet<>();
+        for (String key : jsonObject.keySet()) {
+            if (key.contains(DatabaseConstants.ANOMALY_TIMESTAMP)) {
+                tempSet.add(key);
+            }
+        }
+        tempSet.stream().forEach(jsonObject::remove);
+        lettuceJsonDumper.writeRawData(jsonObject);
+        verify(lettuceJsonDumper, times(1)).writeAnomalyTimestampsToRedis(anyMap());
+        verify(lettuceJsonDumper, times(2)).writeIndexesToRedis(anyMap());
+        verify(lettuceJsonDumper, times(2)).writeObjectsToRedis(anyMap());
+        verify(lettuceJsonDumper, times(2)).writeIdsToRedis(anyMap());
+    }
+
+}

--- a/src/test/resources/redis_json_dump.json
+++ b/src/test/resources/redis_json_dump.json
@@ -1,0 +1,391 @@
+{
+  "ClusterId": "2",
+  "JobId": "5",
+  "clusterIdIndex:all": [
+    "2",
+    "1"
+  ],
+  "deletedIdIndex:all": [
+    "3"
+  ],
+  "emailIdIndex:Emails": [
+    "xyz@abc.com",
+    "pqr@opq.com"
+  ],
+  "emailIdReportsIndex:xyz@abc.com": [
+    "9319e9e6-126e-4048-961f-397a0cc0d85e",
+    "7384d6d9-fe90-4ff1-a1e4-7c0c27689bc6",
+    "faf54eff-ad8a-4163-b408-5c440c96e7dd",
+    "bb64871e-21d5-4b08-b31e-fa9c19752042",
+    "0e47f8ad-e20e-483f-bc23-86b433ce92ab",
+    "b11f48f9-fe33-4ff3-a2b3-1f8f1555c77b",
+    "046f434b-ba8d-4cb7-b37d-3d1770387a45",
+    "6816742e-f0b0-4a6a-9829-7ac6d10cb0db",
+    "05a9b847-3e25-4296-81bb-263c05866a17",
+    "7749b219-f429-46e4-9997-c25cbadb7066",
+    "d960d267-8d8d-4538-949a-bd3398c6d377"
+  ],
+  "emailJobIndex:xyz@abc.com": [
+    "2",
+    "1"
+  ],
+  "emailJobIndex:pqr@opq.com": [
+    "2",
+    "1"
+  ],
+  "emailTriggerIndex:hour": [
+    "pqr@opq.com"
+  ],
+  "emailTriggerIndex:instant": [
+    "xyz@abc.com"
+  ],
+  "frequencyIndex:day": [
+    "faf54eff-ad8a-4163-b408-5c440c96e7dd",
+    "b11f48f9-fe33-4ff3-a2b3-1f8f1555c77b",
+    "041e6386-4cf6-489b-9344-2e46f0731957",
+    "5c7ad379-6029-42ad-83ec-ddf4c1bfd9be",
+    "1412a421-fc57-4ba2-9e4b-7548fb9e231c",
+    "44d09ee2-76dc-424b-829f-111d4f337be7"
+  ],
+  "jobClusterIdIndex:1": [
+    "4",
+    "1",
+    "5",
+    "2"
+  ],
+  "jobIdIndex:all": [
+    "4",
+    "1",
+    "5",
+    "2"
+  ],
+  "jobStatusIndex:CREATED": [
+    "4",
+    "1",
+    "5",
+    "2"
+  ],
+  "jobStatusIndex:NODATA": [
+    "2",
+    "1"
+  ],
+  "jobStatusIndex:RUNNING": [
+    "4",
+    "1",
+    "2"
+  ],
+  "jobStatusIndex:STOPPED": [
+    "4",
+    "1",
+    "2"
+  ],
+  "reportJobIdIndex:1": [
+    "a3038074-ef80-4293-928f-72740dbd0855",
+    "307aeb3b-0564-45c1-b08d-80a3cde941a8",
+    "01f45ab9-1551-4bc0-9f7c-5458fda6ef02"
+  ],
+  "reportJobIdIndex:2": [
+    "0bf223be-7560-4f2c-b462-1d4973d46249",
+    "faf54eff-ad8a-4163-b408-5c440c96e7dd",
+    "92f6c62b-8d12-42ab-b37e-654d5d27d861",
+    "bb64871e-21d5-4b08-b31e-fa9c19752042"
+  ],
+  "reportJobIdIndex:4": [
+    "af41a438-0f9d-4649-9290-00fa37fe3df5",
+    "6ecc0f8d-1f4c-4094-b608-c39b8a4bc03a",
+    "4c5039ab-1d0e-4948-ade0-e7b077d75c7d",
+    "b70d3d78-1b6a-4101-9a9e-76f17c5a5e9d"
+  ],
+  "timestampIndex:25843680": [
+    "04ed98cd-b05a-4a8b-bc61-fcbcf563b6d8",
+    "5c7ad379-6029-42ad-83ec-ddf4c1bfd9be",
+    "31cdfed7-0e71-47cd-93b3-cf6903424abe",
+    "fc31ece0-98ac-40a6-83b9-c868e59664d9"
+  ],
+  "timestampIndex:25845120": [
+    "276a5e11-28c5-484d-85c6-7070bb719f9b"
+  ],
+  "timestampIndex:25860960": [
+    "ec18dcc2-ab90-4ea4-ba4c-541424a37758",
+    "6ecc0f8d-1f4c-4094-b608-c39b8a4bc03a",
+    "b70d3d78-1b6a-4101-9a9e-76f17c5a5e9d",
+    "af41a438-0f9d-4649-9290-00fa37fe3df5",
+    "b9953bc5-3a59-47d5-abee-d247a28752ab",
+    "4c5039ab-1d0e-4948-ade0-e7b077d75c7d",
+    "e03116cb-3361-4f0d-a49e-69d363202b3f"
+  ],
+  "timestampIndex:25873920": [
+    "bb64871e-21d5-4b08-b31e-fa9c19752042",
+    "d1ba4ba6-c4fb-48cd-bb66-b8b893985807",
+    "39586545-9f85-4a5d-8d04-60ebb6f36043",
+    "b11f48f9-fe33-4ff3-a2b3-1f8f1555c77b",
+    "6816742e-f0b0-4a6a-9829-7ac6d10cb0db",
+    "1f4ca93e-b9d9-495a-a79b-2fa4b192afb7",
+    "1a5a4787-8694-4af8-84da-dfabee002000",
+    "1a630044-78ac-4dc5-90b6-dfcd11ca83e5",
+    "7438be86-f393-474d-ad0a-48e8e750497e",
+    "b9499f92-42dd-48b5-bcc7-ab77176bcf59"
+  ],
+  "timestampIndex:25875360": [
+    "568cf002-11c9-48b6-8d6e-19bfc69f11ef",
+    "0bf223be-7560-4f2c-b462-1d4973d46249",
+    "023c8d4e-8712-4d08-9291-45e073fe67ab",
+    "f69d4757-17ea-4fc9-887d-e08226fbb80a",
+    "0c4fd71d-9ca5-466f-97b6-43415cc7216e",
+    "571f9cfa-21b3-4f78-af90-6533fc4ce6ae",
+    "f389c42d-ffa6-4e3f-b23a-ef55c5d90407",
+    "e900b7a8-8ac4-4bab-827b-3730b11026d0",
+    "ded49d5f-f18f-4552-add9-7c79fed1a754",
+    "39d0e4c9-bb31-471a-9043-bfb7df12e320",
+    "590a81f8-ac8f-4cda-bdd0-0fb5c800e7cd",
+    "58991d87-9460-4cf8-96c4-136bd1385f34",
+    "b472376f-1219-4d27-86fc-fd4fa4907518",
+    "5c595219-4e63-48b3-82c9-e588957ad260",
+    "a411b780-4567-47b3-a90d-bf731e947162",
+    "240de70c-984d-4fea-b527-eb399307e7c5",
+    "6c9ceecc-1ff3-46e9-9986-faec4ebfa67a",
+    "99399b83-0bad-492a-838a-35cd71c63e0d"
+  ],
+  "timestampIndex:25876800": [
+    "7749b219-f429-46e4-9997-c25cbadb7066",
+    "041e6386-4cf6-489b-9344-2e46f0731957",
+    "8b05d2b1-142f-4b68-a616-78368f94f5ee"
+  ],
+  "timestampIndex:25878240": [
+    "b8def1f0-a11b-4b55-b705-f18827461570",
+    "faf54eff-ad8a-4163-b408-5c440c96e7dd"
+  ],
+  "timestampIndex:25879680": [
+    "0e47f8ad-e20e-483f-bc23-86b433ce92ab",
+    "3dd6f127-120f-45d2-83c8-228c8cd243b9",
+    "046f434b-ba8d-4cb7-b37d-3d1770387a45"
+  ],
+  "timestampIndex:25881120": [
+    "d2dc6b43-07a9-4f8e-9931-56b5db0f0f28",
+    "c3e297e4-fcbd-4caf-a1c7-1debcf92ea75"
+  ],
+  "timestampIndex:25882560": [
+    "3d3d02e3-2038-431b-bf77-146016e83fec",
+    "a3038074-ef80-4293-928f-72740dbd0855"
+  ],
+  "timestampIndex:25884000": [
+    "a3cf8e4e-5bcc-42a7-8072-7eb0815af3c2",
+    "cae0c94d-2126-4f8b-95e4-7cbed1d1c842"
+  ],
+  "timestampIndex:25885440": [
+    "29501b34-ea07-43a4-8f7d-f3d423c36c5a",
+    "afeb7332-44f7-4832-881d-e14f253af734",
+    "8137c1db-9912-4ab9-9b47-172dca8bc70c",
+    "31c42d3e-0505-4175-b32b-93750671ae80",
+    "ad44e06c-bddc-453b-80c4-0c2791410cec"
+  ],
+  "timestampIndex:25886880": [
+    "44dbae75-e5f8-481f-ad05-26f1c073edb3",
+    "66e4e36a-53f7-4d80-9e29-b79786851270"
+  ],
+  "timestampIndex:25888320": [
+    "dc5d9f01-c390-4f57-a833-9037053188a9",
+    "0ea04a40-4af3-4054-8044-cb2cfb8a04b7"
+  ],
+  "timestampIndex:25889760": [
+    "0c1d3c88-5db7-4ecc-b93a-ac38e424e0fe",
+    "97809a6e-899a-4eeb-ab98-5f035aa475cd"
+  ],
+  "timestampIndex:25891200": [
+    "31609cab-8334-49ee-aca4-6cd482b4d628",
+    "69371f3e-1292-4a11-94bd-83272787dcde"
+  ],
+  "timestampIndex:25892640": [
+    "cada8af8-02a0-4c31-83f0-0f1f3568b4a0",
+    "1412a421-fc57-4ba2-9e4b-7548fb9e231c",
+    "307aeb3b-0564-45c1-b08d-80a3cde941a8"
+  ],
+  "timestampIndex:25894080": [
+    "fa7a8610-a409-4e34-8a1d-7322e332d0d9",
+    "d10e0b3f-9875-4d52-9944-e34b09264af5",
+    "8af62e22-f3fc-409d-bdd7-384686de1621"
+  ],
+  "DeletedJobs:3": {
+    "hoursOfLag": "12",
+    "frequency": "day",
+    "testName": "test1",
+    "granularityRange": "1",
+    "jobId": "3",
+    "url": "",
+    "granularity": "day",
+    "effectiveQueryTime": "",
+    "owner": "owner1",
+    "testDescription": "",
+    "anomalyDetectionModel": "KSigmaModel",
+    "emailOnNoData": "false",
+    "userQuery": "{}",
+    "jobStatus": "CREATED",
+    "timeseriesRange": "28",
+    "timeseriesModel": "OlympicModel",
+    "query": "{}",
+    "sigmaThreshold": "3.0",
+    "effectiveRunTime": "",
+    "clusterId": "1",
+    "ownerEmail": ""
+  },
+  "DruidClusters:1": {
+    "protocol": "http",
+    "brokerPort": "4080",
+    "hoursOfLag": "0",
+    "clusterName": "cluster1",
+    "brokerHost": "bkr.abc.com",
+    "clusterDescription": "",
+    "clusterId": "1",
+    "brokerEndpoint": "druid/v2"
+  },
+  "DruidClusters:2": {
+    "protocol": "http",
+    "brokerPort": "4080",
+    "hoursOfLag": "5",
+    "clusterName": "cl3",
+    "brokerHost": "brk.opq.com",
+    "clusterDescription": "blah",
+    "clusterId": "2",
+    "brokerEndpoint": "druid/v2"
+  },
+  "Emails:xyz@abc.com": {
+    "sendOutHour": "12",
+    "sendOutMinute": "00",
+    "repeatInterval": "instant",
+    "emailId": "xyz@abc.com"
+  },
+  "Emails:pqr@opq.com": {
+    "sendOutHour": "12",
+    "sendOutMinute": "7",
+    "repeatInterval": "hour",
+    "emailId": "pqr@opq.com"
+  },
+  "Jobs:1": {
+    "testName": "test",
+    "hoursOfLag": "0",
+    "ownerEmail": "xyz@abc.com",
+    "granularityRange": "1",
+    "jobId": "1",
+    "url": "",
+    "granularity": "day",
+    "owner": "owner",
+    "testDescription": "",
+    "anomalyDetectionModel": "KSigmaModel",
+    "emailOnNoData": "true",
+    "userQuery": "{}",
+    "jobStatus": "STOPPED",
+    "timeseriesRange": "28",
+    "timeseriesModel": "OlympicModel",
+    "sigmaThreshold": "3.0",
+    "query": "{}",
+    "effectiveRunTime": "25909921",
+    "frequency": "day",
+    "clusterId": "1",
+    "effectiveQueryTime": "25909920"
+  },
+  "Jobs:2": {
+    "testName": "tess",
+    "hoursOfLag": "0",
+    "ownerEmail": "pqr@opq.com,xyz@abc.com",
+    "granularityRange": "1",
+    "jobId": "2",
+    "url": "",
+    "granularity": "day",
+    "owner": "jigar",
+    "testDescription": "",
+    "anomalyDetectionModel": "KSigmaModel",
+    "emailOnNoData": "true",
+    "userQuery": "{}",
+    "jobStatus": "STOPPED",
+    "timeseriesRange": "28",
+    "timeseriesModel": "OlympicModel",
+    "sigmaThreshold": "3.0",
+    "query": "{}",
+    "effectiveRunTime": "25909922",
+    "frequency": "day",
+    "clusterId": "1",
+    "effectiveQueryTime": "25909920"
+  },
+  "Reports:01f45ab9-1551-4bc0-9f7c-5458fda6ef02": {
+    "deviationString": "-41",
+    "queryURL": "",
+    "jobId": "1",
+    "modelName": "KSigmaModel",
+    "metricName": "m1",
+    "jobFrequency": "day",
+    "modelParam": "3.0",
+    "groupByFilters": "filter1, filter2",
+    "uniqueId": "01f45ab9-1551-4bc0-9f7c-5458fda6ef02",
+    "reportQueryEndTime": "25896960",
+    "status": "warning",
+    "testName": "test"
+  },
+  "Reports:023c8d4e-8712-4d08-9291-45e073fe67ab": {
+    "deviationString": "",
+    "queryURL": "",
+    "jobId": "2",
+    "modelName": "",
+    "metricName": "",
+    "jobFrequency": "day",
+    "modelParam": "",
+    "groupByFilters": "",
+    "uniqueId": "023c8d4e-8712-4d08-9291-45e073fe67ab",
+    "reportQueryEndTime": "25875360",
+    "status": "nodata",
+    "testName": "tess"
+  },
+  "Reports:0c1d3c88-5db7-4ecc-b93a-ac38e424e0fe": {
+    "deviationString": "",
+    "queryURL": "",
+    "jobId": "2",
+    "modelName": "",
+    "metricName": "",
+    "jobFrequency": "day",
+    "modelParam": "",
+    "groupByFilters": "",
+    "uniqueId": "0c1d3c88-5db7-4ecc-b93a-ac38e424e0fe",
+    "reportQueryEndTime": "25889760",
+    "status": "success",
+    "testName": "tess"
+  },
+  "Reports:01f45ab9-1551-4bc0-9f7c-5458fda6ef02:anomalyTimestamps:start": [
+    {
+      "score": 0.0,
+      "value": [
+        6,
+        -106,
+        0
+      ]
+    }
+  ],
+  "Reports:041e6386-4cf6-489b-9344-2e46f0731957:anomalyTimestamps:start": [
+    {
+      "score": 0.0,
+      "value": [
+        6,
+        -108,
+        -80
+      ]
+    }
+  ],
+  "Reports:046f434b-ba8d-4cb7-b37d-3d1770387a45:anomalyTimestamps:start": [
+    {
+      "score": 0.0,
+      "value": [
+        6,
+        -108,
+        -32
+      ]
+    }
+  ],
+  "Reports:4d0356ef-351c-4597-b801-e948bd234e60:anomalyTimestamps:start": [
+    {
+      "score": 0.0,
+      "value": [
+        6,
+        -106,
+        120
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Issue #18 : updated maven surefire version to 3.0.0-M3**

**Description of changes:**
1. Previously all the job reports are set instantly after the job completion. Now, per job email metadata is added in redis to keep track of `email -> job` & `email -> reports` relationship to trigger emails, about available job reports in redis, at user specified time. User can go to meta-manager UI and manage the email trigger time per email.

2. Added support for redis back up in two ways: 1) is backing up redis dump in local redis dump file periodically by executing `bgsave` explicitly every day midnight. 2) user can use `--backup-redis-db-path` CLI config(refer README) to specify redis json dump location to store redis data in json formated file. In the case of redis data loss user can use `/Debug/Restore` endpoint to submit the json data file location to restore redis data.

3. For security, user can specify allowed druid broker urls to connect using a whitelist file. `--druid-brokers-list-file` CLI setting(refer README) can be used to specify the location to whitelist file.

4. Bugfix in the case where druid query grouping dimension can be a json object(javascript function). Now query parser checks for json object and allows it as a group by dimension.
 
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
