### PR TITLE
Added Support for Union of DataSources Query 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - mvn install
 after_success:

--- a/src/main/java/com/yahoo/sherlock/query/Query.java
+++ b/src/main/java/com/yahoo/sherlock/query/Query.java
@@ -178,7 +178,20 @@ public class Query {
             if (this.queryObj.get(QueryConstants.DATASOURCE).isJsonPrimitive()) {
                 return this.queryObj.get(QueryConstants.DATASOURCE);
             } else if (this.queryObj.get(QueryConstants.DATASOURCE).isJsonObject()) {
-                return this.queryObj.getAsJsonObject(QueryConstants.DATASOURCE).get(QueryConstants.NAME);
+                JsonObject dataSourceInfo = this.queryObj.getAsJsonObject(QueryConstants.DATASOURCE);
+                String dataSourceType = dataSourceInfo.get(QueryConstants.TYPE).getAsString();
+                //ref : https://druid.apache.org/docs/latest/querying/datasource.html
+                JsonElement dataSource;
+                switch (dataSourceType) {
+                    case QueryConstants.UNION:
+                        dataSource = dataSourceInfo.get(QueryConstants.DATASOURCES);
+                        break;
+                    default:
+                        dataSource = dataSourceInfo.get(QueryConstants.NAME);
+                        break;
+                }
+
+                return dataSource;
             }
         }
         return null;

--- a/src/main/java/com/yahoo/sherlock/service/DetectorService.java
+++ b/src/main/java/com/yahoo/sherlock/service/DetectorService.java
@@ -93,27 +93,24 @@ public class DetectorService {
      * @throws DruidException if the datasource is not found
      */
     public void checkDatasource(Query query, DruidCluster cluster) throws DruidException {
-        JsonElement datasourceInfo = query.getDatasource();
         ArrayList<String> inValidDataSources = new ArrayList<>();
+        JsonElement datasourceInfo = query.getDatasource();
         JsonArray druidDataSources = httpService.queryDruidDatasources(cluster);
-        boolean isValidDataSource = true;
         if (datasourceInfo.isJsonArray()) {
             JsonArray dataSources = datasourceInfo.getAsJsonArray();
             for (JsonElement dataSource :
                     dataSources) {
                 if (!druidDataSources.contains(dataSource)) {
-                    isValidDataSource = false;
                     inValidDataSources.add(dataSource.getAsString());
                 }
             }
         } else {
             if (!druidDataSources.contains(datasourceInfo)) {
-                isValidDataSource = false;
                 inValidDataSources.add(datasourceInfo.getAsString());
             }
         }
 
-        if (!isValidDataSource) {
+        if (inValidDataSources.size() > 0) {
             log.error("Druid datasource {} does not exist!", inValidDataSources.toString());
             throw new DruidException("Querying unknown datasource: " + inValidDataSources.toString());
         }

--- a/src/main/java/com/yahoo/sherlock/service/DetectorService.java
+++ b/src/main/java/com/yahoo/sherlock/service/DetectorService.java
@@ -68,8 +68,8 @@ public class DetectorService {
      * Method to detect anomalies.
      * This method handles the control/data flow between the components of detection system.
      *
-     * @param cluster           the Druid query to issue the query
-     * @param jobMetadata       job metadata
+     * @param cluster     the Druid query to issue the query
+     * @param jobMetadata job metadata
      * @return list of anomalies
      * @throws SherlockException exeption thrown while runnig the anomaly detector components
      * @throws DruidException    if an error querying druid occurs
@@ -93,11 +93,22 @@ public class DetectorService {
      * @throws DruidException if the datasource is not found
      */
     public void checkDatasource(Query query, DruidCluster cluster) throws DruidException {
-        JsonElement datasource = query.getDatasource();
-        JsonArray druidDatasources = httpService.queryDruidDatasources(cluster);
-        if (!druidDatasources.contains(datasource)) {
-            log.error("Druid datasource {} does not exist!", datasource);
-            throw new DruidException("Querying unknown datasource: " + datasource);
+        JsonElement datasourceInfo = query.getDatasource();
+        JsonArray druidDataSources = httpService.queryDruidDatasources(cluster);
+        boolean isValidDataSource = true;
+        if (datasourceInfo.isJsonArray()) {
+            JsonArray dataSources = datasourceInfo.getAsJsonArray();
+            for (JsonElement dataSource :
+                    dataSources) {
+                isValidDataSource = (isValidDataSource && (druidDataSources.contains(dataSource)));
+            }
+        } else {
+            isValidDataSource = druidDataSources.contains(datasourceInfo);
+        }
+
+        if (!isValidDataSource) {
+            log.error("Druid datasource {} does not exist!", datasourceInfo);
+            throw new DruidException("Querying unknown datasource: " + datasourceInfo);
         }
     }
 

--- a/src/main/java/com/yahoo/sherlock/settings/QueryConstants.java
+++ b/src/main/java/com/yahoo/sherlock/settings/QueryConstants.java
@@ -20,6 +20,7 @@ public class QueryConstants {
     // Query constants
     public static final String AGGREGATOR = "aggregator";
     public static final String NAME = "name";
+    public static final String DATASOURCES= "dataSources";
     public static final String DIMENSIONS = "dimensions";
     public static final String DIMENSION = "dimension";
     public static final String DATE_TIME_SPLIT = "\\.";
@@ -27,9 +28,11 @@ public class QueryConstants {
     public static final String PERIOD = "period";
     public static final String DATASOURCE = "dataSource";
     public static final String ORIGIN = "origin";
+    public static final String TABLE = "table";
     public static final String TYPE = "type";
     public static final String TIMEZONE = "timeZone";
     public static final String UTC = "UTC";
     public static final String OUTPUT_NAME = "outputName";
     public static final String UNKNOWN = "unknown";
+    public static final String UNION = "union";
 }

--- a/src/test/java/com/yahoo/sherlock/query/QueryTest.java
+++ b/src/test/java/com/yahoo/sherlock/query/QueryTest.java
@@ -71,7 +71,7 @@ public class QueryTest {
                     add("dim1");
                 }
             };
-            JsonElement expectedElement = gson.toJsonTree(new String[]{"s1"});
+            JsonElement expectedElement = gson.toJsonTree(new String[]{"s1" , "s2"});
             Assert.assertEquals(dimExpected, query.getGroupByDimensions());
             Assert.assertEquals(Collections.singletonList("m3"), query.getMetricNames());
             Assert.assertTrue(query.getDatasource().isJsonArray());

--- a/src/test/java/com/yahoo/sherlock/query/QueryTest.java
+++ b/src/test/java/com/yahoo/sherlock/query/QueryTest.java
@@ -7,6 +7,7 @@
 package com.yahoo.sherlock.query;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -60,5 +61,23 @@ public class QueryTest {
             Assert.fail();
         }
 
+        try {
+            Gson gson = new Gson();
+            String queryString = new String(Files.readAllBytes(Paths.get("src/test/resources/druid_query_4.json")));
+            JsonObject queryJsonObject = gson.fromJson(queryString, JsonObject.class);
+            query = new Query(queryJsonObject, 123, 1234, Granularity.HOUR, 1);
+            LinkedHashSet<String> dimExpected = new LinkedHashSet<String>() {
+                {
+                    add("dim1");
+                }
+            };
+            JsonElement expectedElement = gson.toJsonTree(new String[]{"s1"});
+            Assert.assertEquals(dimExpected, query.getGroupByDimensions());
+            Assert.assertEquals(Collections.singletonList("m3"), query.getMetricNames());
+            Assert.assertTrue(query.getDatasource().isJsonArray());
+            Assert.assertEquals(expectedElement, query.getDatasource());
+        } catch (Exception e) {
+            Assert.fail();
+        }
     }
 }

--- a/src/test/resources/druid_query_4.json
+++ b/src/test/resources/druid_query_4.json
@@ -52,7 +52,7 @@
   "intervals": "2017-09-15T20:48:28+00:00/2017-10-13T20:48:28+00:00",
   "dataSource": {
     "type":"union",
-    "dataSources": ["s1"]
+    "dataSources": ["s1", "s2"]
   },
   "granularity": "day",
   "threshold": 50,

--- a/src/test/resources/druid_query_4.json
+++ b/src/test/resources/druid_query_4.json
@@ -1,0 +1,79 @@
+{
+  "metric": "m1",
+  "aggregations": [
+    {
+      "filter": {
+        "fields": [
+          {
+            "type": "selector",
+            "dimension": "d1",
+            "value": "v1"
+          },
+          {
+            "type": "selector",
+            "dimension": "d2",
+            "value": "v2"
+          },
+          {
+            "type": "selector",
+            "dimension": "d3",
+            "value": "v3"
+          }
+        ],
+        "type": "and"
+      },
+      "aggregator": {
+        "fieldName": "f1",
+        "type": "longSum",
+        "name": "m1"
+      },
+      "type": "filtered"
+    },
+    {
+      "filter": {
+        "fields": [
+          {
+            "type": "selector",
+            "dimension": "d4",
+            "value": "v4"
+          }
+        ],
+        "type": "or"
+      },
+      "aggregator": {
+        "fieldName": "f2",
+        "type": "longSum",
+        "name": "n1"
+      },
+      "type": "filtered"
+    }
+  ],
+  "dimension": "dim1",
+  "intervals": "2017-09-15T20:48:28+00:00/2017-10-13T20:48:28+00:00",
+  "dataSource": {
+    "type":"union",
+    "dataSources": ["s1"]
+  },
+  "granularity": "day",
+  "threshold": 50,
+  "postAggregations": [
+    {
+      "fields": [
+        {
+          "fieldName": "m1",
+          "type": "fieldAccess",
+          "name": "m1"
+        },
+        {
+          "fieldName": "f3",
+          "type": "fieldAccess",
+          "name": "n3"
+        }
+      ],
+      "type": "arithmetic",
+      "name": "m3",
+      "fn": "/"
+    }
+  ],
+  "queryType": "topN"
+}


### PR DESCRIPTION
solves issue https://github.com/yahoo/sherlock/issues/24
# Description of changes:
  - support for union query on multiple data sources has been added. keeping existing compatibility of code for table dataSource.

eg. 
```yaml
{
       "type": "union",
       "dataSources": ["<string_value1>", "<string_value2>", "<string_value3>", ... ]
}
```
 - minor changes in travis.yml (use openjdk8 instead of oraclejdk8)

@jigs1993 can you please review




<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
