### PR TITLE
Added authentification for SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ Jeff Niu, [jeffniu22@gmail.com](mailto:jeffniu22@gmail.com)
 
 Josh Walters, [josh@joshwalters.com](mailto:josh@joshwalters.com)
 
+Stephan Stiefel, [Stephan3555](linkto:https://github.com/Stephan3555)
+
 ## License
 
 Code licensed under the [GPL v3 License](https://www.gnu.org/licenses/quick-guide-gplv3.en.html). See LICENSE file for terms.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ java -Dlog4j.configuration=file:${path_to_log4j}/log4j.properties \
 | --reply-to                | if email `enabled`  |             | [reply-to](#reply-to)                               |
 | --smtp-host               | if email `enabled`  |             | [smtp-host](#smtp-host)                             |
 | --smtp-port               |    -                | `25`        | [smtp-port](#smtp-port)                             |
+| --smtp-user               |    -                |             | [smtp-user](#smtp-user)                             |
+| --smtp-password           |    -                |             | [smtp-password](#smtp-password)                     |
 | --failure-email           | if email `enabled`  |             | [failure-email](#failure-email)                     |
 | --execution-delay         |    -                | `30`        | [execution-delay](#execution-delay)                 |
 | --valid-domains           |    -                | `null`      | [valid-domains](#valid-domains)                     |
@@ -231,6 +233,10 @@ The handle's `REPLY TO` email where replies will be sent.
 The email service's `SMTP HOST`.
 #### smtp-port
 The email service's `SMTP PORT`. The default value is `25`.
+#### smtp-user
+The email service's `SMTP USER`.
+#### smtp-password
+The email service's `SMTP PASSWORD`.
 #### failure-email
 A dedicated email which may be set to receive job failure notifications.
 #### execution-delay

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.8.11.1,)</version>
+            <version>[2.10.3,)</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/src/main/java/com/yahoo/sherlock/service/EmailService.java
+++ b/src/main/java/com/yahoo/sherlock/service/EmailService.java
@@ -272,7 +272,7 @@ public class EmailService {
     protected boolean sendFormattedEmail(Email emailHandle) {
         try {
             new Mailer(
-                new ServerConfig(CLISettings.SMTP_HOST, CLISettings.SMTP_PORT),
+                new ServerConfig(CLISettings.SMTP_HOST, CLISettings.SMTP_PORT, CLISettings.SMTP_USER, CLISettings.SMTP_PASSWORD),
                 TransportStrategy.SMTP_TLS
             ).sendMail(emailHandle);
             log.info("Email sent successfully!");

--- a/src/main/java/com/yahoo/sherlock/settings/CLISettings.java
+++ b/src/main/java/com/yahoo/sherlock/settings/CLISettings.java
@@ -120,6 +120,18 @@ public class CLISettings {
     public static int SMTP_PORT = 25;
 
     /**
+     * SMTP user setting.
+     */
+    @Parameter(names = "--smtp-user", description = "SMTP USER setting for email service.")
+    public static String SMTP_USER;
+
+    /**
+     * SMTP password setting.
+     */
+    @Parameter(names = "--smtp-password", description = "SMTP USER setting for email service.")
+    public static String SMTP_PASSWORD;
+
+    /**
      * Job email address for failures.
      */
     @Parameter(names = "--failure-email", description = "email to recieve pipeline failures.", validateWith = EmailValidator.class)


### PR DESCRIPTION
Solves: https://github.com/yahoo/sherlock/issues/30

Added the option to add authentification for SMTP.
Based on the documenation:

https://www.javadoc.io/doc/org.simplejavamail/simple-java-mail/4.0.0/org/simplejavamail/mailer/config/ServerConfig.html

The additional parameters are optional and can be null. Therefore nothing changes really much

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
