### PR TITLE
Allow Sherlock to Query to empty DataSources

### DIFF
--- a/src/test/java/com/yahoo/sherlock/service/DetectorServiceTest.java
+++ b/src/test/java/com/yahoo/sherlock/service/DetectorServiceTest.java
@@ -162,7 +162,8 @@ public class DetectorServiceTest {
             detectorService.detect(DBTestHelper.getNewDruidCluster(), job);
             Assert.fail();
         } catch (Exception e) {
-            assertEquals(e.getMessage(), "Querying unknown datasource: [s1]");
+            //Change test from Querying unknown datasource: [s1] to null since we are removing the DataSource.
+            assertEquals(e.getMessage(), null);
         }
     }
 


### PR DESCRIPTION
This PR changes this files.

```
#	modified:   src/main/java/com/yahoo/sherlock/query/Query.java
#	modified:   src/main/java/com/yahoo/sherlock/service/DetectorService.java
#	modified:   src/test/java/com/yahoo/sherlock/service/DetectorServiceTest.java
```

Now sherlock can perform querys to empty Druid DataSources